### PR TITLE
Hardcore Prototype

### DIFF
--- a/Content/sql/weenies/10977 Virindi Implant - virindiimplant2-xp.sql
+++ b/Content/sql/weenies/10977 Virindi Implant - virindiimplant2-xp.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 10977;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (10977, 'virindiimplant2-xp', 35, '2005-02-09 10:00:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (10977,   1,      32768) /* ItemType - Caster */
+     , (10977,   5,         50) /* EncumbranceVal */
+     , (10977,   8,         50) /* Mass */
+     , (10977,   9,   16777216) /* ValidLocations - Held */
+     , (10977,  16,    6291464) /* ItemUseable - SourceContainedTargetRemoteNeverWalk */
+     , (10977,  18,          1) /* UiEffects - Magical */
+     , (10977,  19,      11450) /* Value */
+     , (10977,  46,        512) /* DefaultCombatStyle - Magic */
+     , (10977,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (10977,  94,         16) /* TargetType - Creature */
+     , (10977, 106,        270) /* ItemSpellcraft */
+     , (10977, 107,        600) /* ItemCurMana */
+     , (10977, 108,        600) /* ItemMaxMana */
+     , (10977, 115,        225) /* ItemSkillLevelLimit */
+     , (10977, 117,        300) /* ItemManaCost */
+     , (10977, 150,        103) /* HookPlacement - Hook */
+     , (10977, 151,          2) /* HookType - Wall */
+     , (10977, 280,       1001) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (10977,  22, True ) /* Inscribable */
+     , (10977,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (10977,   5,   -0.05) /* ManaRate */
+     , (10977,  29,       1) /* WeaponDefense */
+     , (10977, 144,    0.05) /* ManaConversionMod */
+     , (10977, 167,      10) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (10977,   1, 'Virindi Implant') /* Name */
+     , (10977,  16, 'A reddish, veined lump, pulled from the chest cavity of a Hea Tumerok hunting reedshark named Sahkurea.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (10977,   1, 0x02000B29) /* Setup */
+     , (10977,   3, 0x20000014) /* SoundTable */
+     , (10977,   8, 0x0600217F) /* Icon */
+     , (10977,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (10977,  27, 0x400000E1) /* UseUserAnimation - UseMagicWand */
+     , (10977,  28,       2419) /* Spell - Panic Attack */
+     , (10977,  37,         27) /* ItemSkillLimit - CreatureEnchantment */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (10977,  2451,      2)  /* Hunter's Acumen */;

--- a/Content/sql/weenies/23132 Lugian Axe - lugianaxehollowvod.sql
+++ b/Content/sql/weenies/23132 Lugian Axe - lugianaxehollowvod.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 23132;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (23132, 'lugianaxehollowvod', 6, '2005-02-09 10:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (23132,   1,          1) /* ItemType - MeleeWeapon */
+     , (23132,   5,       6400) /* EncumbranceVal */
+     , (23132,   8,       2560) /* Mass */
+     , (23132,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (23132,  16,          1) /* ItemUseable - No */
+     , (23132,  19,        750) /* Value */
+     , (23132,  36,       9999) /* ResistMagic */
+     , (23132,  44,         50) /* Damage */
+     , (23132,  45,          1) /* DamageType - Slash */
+     , (23132,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (23132,  47,          4) /* AttackType - Slash */
+     , (23132,  48,          1) /* WeaponSkill - Axe */
+     , (23132,  49,         80) /* WeaponTime */
+     , (23132,  51,          1) /* CombatUse - Melee */
+     , (23132,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (23132, 150,        103) /* HookPlacement - Hook */
+     , (23132, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (23132,  22, True ) /* Inscribable */
+     , (23132,  65, True ) /* IgnoreMagicResist */
+     , (23132,  66, True ) /* IgnoreMagicArmor */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (23132,  21,     1.5) /* WeaponLength */
+     , (23132,  22,     0.5) /* DamageVariance */
+     , (23132,  29,       1) /* WeaponDefense */
+     , (23132,  39,       2) /* DefaultScale */
+     , (23132,  62,       1) /* WeaponOffense */
+     , (23132,  76,     0.7) /* Translucency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (23132,   1, 'Lugian Axe') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (23132,   1, 0x02000126) /* Setup */
+     , (23132,   3, 0x20000014) /* SoundTable */
+     , (23132,   8, 0x060010BC) /* Icon */
+     , (23132,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Content/sql/weenies/23133 Rock - lugianboulderhollowvod.sql
+++ b/Content/sql/weenies/23133 Rock - lugianboulderhollowvod.sql
@@ -1,0 +1,55 @@
+DELETE FROM `weenie` WHERE `class_Id` = 23133;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (23133, 'lugianboulderhollowvod', 4, '2005-02-09 10:00:00') /* Missile */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (23133,   1,        256) /* ItemType - MissileWeapon */
+     , (23133,   5,        500) /* EncumbranceVal */
+     , (23133,   8,        500) /* Mass */
+     , (23133,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (23133,  11,         30) /* MaxStackSize */
+     , (23133,  12,          1) /* StackSize */
+     , (23133,  13,        500) /* StackUnitEncumbrance */
+     , (23133,  14,        500) /* StackUnitMass */
+     , (23133,  15,          1) /* StackUnitValue */
+     , (23133,  16,          1) /* ItemUseable - No */
+     , (23133,  19,          1) /* Value */
+     , (23133,  33,         -2) /* Bonded - Destroy */
+     , (23133,  36,       9999) /* ResistMagic */
+     , (23133,  44,         50) /* Damage */
+     , (23133,  45,          4) /* DamageType - Bludgeon */
+     , (23133,  46,        128) /* DefaultCombatStyle - ThrownWeapon */
+     , (23133,  48,         12) /* WeaponSkill - ThrownWeapon */
+     , (23133,  49,         20) /* WeaponTime */
+     , (23133,  51,          2) /* CombatUse - Missile */
+     , (23133,  93,     132116) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, Inelastic */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (23133,   1, True ) /* Stuck */
+     , (23133,  17, True ) /* Inelastic */
+     , (23133,  23, True ) /* DestroyOnSell */
+     , (23133,  65, True ) /* IgnoreMagicResist */
+     , (23133,  66, True ) /* IgnoreMagicArmor */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (23133,  21,     1.5) /* WeaponLength */
+     , (23133,  22,     0.5) /* DamageVariance */
+     , (23133,  26,      45) /* MaximumVelocity */
+     , (23133,  27,       1) /* RotationSpeed */
+     , (23133,  29,       1) /* WeaponDefense */
+     , (23133,  39,       1) /* DefaultScale */
+     , (23133,  44,       0) /* TimeToRot */
+     , (23133,  62,       1) /* WeaponOffense */
+     , (23133,  76,     0.7) /* Translucency */
+     , (23133,  78,       1) /* Friction */
+     , (23133,  79,       0) /* Elasticity */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (23133,   1, 'Rock') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (23133,   1, 0x02000597) /* Setup */
+     , (23133,   3, 0x2000005B) /* SoundTable */
+     , (23133,   8, 0x0600106C) /* Icon */
+     , (23133,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Content/sql/weenies/23134 Lugian Morning Star - lugianmorningstarhollowvod.sql
+++ b/Content/sql/weenies/23134 Lugian Morning Star - lugianmorningstarhollowvod.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 23134;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (23134, 'lugianmorningstarhollowvod', 6, '2005-02-09 10:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (23134,   1,          1) /* ItemType - MeleeWeapon */
+     , (23134,   5,      11040) /* EncumbranceVal */
+     , (23134,   8,       3680) /* Mass */
+     , (23134,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (23134,  16,          1) /* ItemUseable - No */
+     , (23134,  19,        850) /* Value */
+     , (23134,  36,       9999) /* ResistMagic */
+     , (23134,  44,         50) /* Damage */
+     , (23134,  45,          2) /* DamageType - Pierce */
+     , (23134,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (23134,  47,          4) /* AttackType - Slash */
+     , (23134,  48,          5) /* WeaponSkill - Mace */
+     , (23134,  49,         80) /* WeaponTime */
+     , (23134,  51,          1) /* CombatUse - Melee */
+     , (23134,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (23134, 150,        103) /* HookPlacement - Hook */
+     , (23134, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (23134,  22, True ) /* Inscribable */
+     , (23134,  65, True ) /* IgnoreMagicResist */
+     , (23134,  66, True ) /* IgnoreMagicArmor */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (23134,  21,     1.8) /* WeaponLength */
+     , (23134,  22,     0.5) /* DamageVariance */
+     , (23134,  29,       1) /* WeaponDefense */
+     , (23134,  39,       2) /* DefaultScale */
+     , (23134,  62,       1) /* WeaponOffense */
+     , (23134,  76,     0.7) /* Translucency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (23134,   1, 'Lugian Morning Star') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (23134,   1, 0x0200013C) /* Setup */
+     , (23134,   3, 0x20000014) /* SoundTable */
+     , (23134,   8, 0x060010D0) /* Icon */
+     , (23134,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Content/sql/weenies/23570 Virindi Paradox - virindiparadox - Level 235.sql
+++ b/Content/sql/weenies/23570 Virindi Paradox - virindiparadox - Level 235.sql
@@ -1,0 +1,216 @@
+DELETE FROM `weenie` WHERE `class_Id` = 23570;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (23570, 'virindiparadox', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (23570,   1,         16) /* ItemType - Creature */
+     , (23570,   2,         19) /* CreatureType - Virindi */
+     , (23570,   3,         39) /* PaletteTemplate - Black */
+     , (23570,   6,         -1) /* ItemsCapacity */
+     , (23570,   7,         -1) /* ContainersCapacity */
+     , (23570,  16,          1) /* ItemUseable - No */
+     , (23570,  25,        235) /* Level */
+     , (23570,  27,          0) /* ArmorType - None */
+     , (23570,  68,          3) /* TargetingTactic - Random, Focused */
+     , (23570,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (23570, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (23570, 140,          1) /* AiOptions - CanOpenDoors */
+     , (23570, 146,    1292189) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (23570,   1, True ) /* Stuck */
+     , (23570,   6, False) /* AiUsesMana */
+     , (23570,  11, False) /* IgnoreCollisions */
+     , (23570,  12, True ) /* ReportCollisions */
+     , (23570,  13, False) /* Ethereal */
+     , (23570, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (23570,   1,       5) /* HeartbeatInterval */
+     , (23570,   2,       0) /* HeartbeatTimestamp */
+     , (23570,   3,    10.6) /* HealthRate */
+     , (23570,   4,    20.5) /* StaminaRate */
+     , (23570,   5,      20) /* ManaRate */
+     , (23570,  12,     0.1) /* Shade */
+     , (23570,  13,       1) /* ArmorModVsSlash */
+     , (23570,  14,       1) /* ArmorModVsPierce */
+     , (23570,  15,       1) /* ArmorModVsBludgeon */
+     , (23570,  16,       1) /* ArmorModVsCold */
+     , (23570,  17,       1) /* ArmorModVsFire */
+     , (23570,  18,       1) /* ArmorModVsAcid */
+     , (23570,  19,       1) /* ArmorModVsElectric */
+     , (23570,  31,      20) /* VisualAwarenessRange */
+     , (23570,  34,       1) /* PowerupTime */
+     , (23570,  36,       1) /* ChargeSpeed */
+     , (23570,  64,       1) /* ResistSlash */
+     , (23570,  65,       1) /* ResistPierce */
+     , (23570,  66,       1) /* ResistBludgeon */
+     , (23570,  67,       1) /* ResistFire */
+     , (23570,  68,    0.65) /* ResistCold */
+     , (23570,  69,       1) /* ResistAcid */
+     , (23570,  70,    0.65) /* ResistElectric */
+     , (23570,  71,       1) /* ResistHealthBoost */
+     , (23570,  72,       1) /* ResistStaminaDrain */
+     , (23570,  73,       1) /* ResistStaminaBoost */
+     , (23570,  74,       1) /* ResistManaDrain */
+     , (23570,  75,       1) /* ResistManaBoost */
+     , (23570,  80,       3) /* AiUseMagicDelay */
+     , (23570, 104,      10) /* ObviousRadarRange */
+     , (23570, 122,       2) /* AiAcquireHealth */
+     , (23570, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (23570,   1, 'Virindi Paradox') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (23570,   1, 0x02000F47) /* Setup */
+     , (23570,   2, 0x09000028) /* MotionTable */
+     , (23570,   3, 0x20000012) /* SoundTable */
+     , (23570,   4, 0x3000000D) /* CombatTable */
+     , (23570,   6, 0x0400150A) /* PaletteBase */
+     , (23570,   7, 0x10000481) /* ClothingBase */
+     , (23570,   8, 0x06002B13) /* Icon */
+     , (23570,  22, 0x34000029) /* PhysicsEffectTable */
+     , (23570,  35,         26) /* DeathTreasureType - T6_Boss_MedAmount - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (23570,   1, 340, 0, 0) /* Strength */
+     , (23570,   2, 320, 0, 0) /* Endurance */
+     , (23570,   3, 380, 0, 0) /* Quickness */
+     , (23570,   4, 360, 0, 0) /* Coordination */
+     , (23570,   5, 350, 0, 0) /* Focus */
+     , (23570,   6, 350, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (23570,   1,  4840, 0, 0, 5000) /* MaxHealth */
+     , (23570,   3,  5680, 0, 0, 6000) /* MaxStamina */
+     , (23570,   5,  3650, 0, 0, 4000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (23570,  2, 0, 2, 0,   0, 0, 0) /* Bow                 Trained */
+     , (23570,  4, 0, 3, 0, 300, 0, 0) /* Dagger              Specialized */
+     , (23570,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
+     , (23570,  7, 0, 3, 0, 425, 0, 0) /* MissileDefense      Specialized */
+     , (23570, 14, 0, 3, 0, 300, 0, 0) /* ArcaneLore          Specialized */
+     , (23570, 15, 0, 3, 0, 315, 0, 0) /* MagicDefense        Specialized */
+     , (23570, 20, 0, 3, 0, 250, 0, 0) /* Deception           Specialized */
+     , (23570, 24, 0, 3, 0,  90, 0, 0) /* Run                 Specialized */
+     , (23570, 31, 0, 3, 0, 250, 0, 0) /* CreatureEnchantment Specialized */
+     , (23570, 33, 0, 3, 0, 250, 0, 0) /* LifeMagic           Specialized */
+     , (23570, 34, 0, 3, 0, 250, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (23570,  0,  1,  0,    0,  600,  600,  600,  600,  600,  600,  600,  600,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (23570,  1,  1,  0,    0,  600,  600,  600,  600,  600,  600,  600,  600,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (23570,  2,  1,  0,    0,  600,  600,  600,  600,  600,  600,  600,  600,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen */
+     , (23570,  3,  1,  0,    0,  600,  600,  600,  600,  600,  600,  600,  600,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (23570,  4,  1,  0,    0,  600,  600,  600,  600,  600,  600,  600,  600,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm */
+     , (23570,  5,  1, 175, 0.75,  600,  600,  600,  600,  600,  600,  600,  600,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (23570, 17,  1,  0,    0,  600,  600,  600,  600,  600,  600,  600,  600,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (23570,   279,      2)  /* Magic Resistance Self VI */
+     , (23570,  1784,   2.04)  /* Horizon's Blades */
+     , (23570,  1785,   2.04)  /* Cassius' Ring of Fire */
+     , (23570,  2053,      2)  /* Executor's Blessing */
+     , (23570,  2074,   2.04)  /* Gossamer Flesh */
+     , (23570,  2129,  2.055)  /* Sizzling Fury */
+     , (23570,  2147,  2.055)  /* Rending Wind */
+     , (23570,  2164,   2.04)  /* Swordsman's Gift */
+     , (23570,  2170,   2.04)  /* Inferno's Gift */
+     , (23570,  2328,      2)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (23570,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (23570, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  3 /* Death */,   0.02, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'As the Paradox ceases a tendril of wispy darkness streaks outward toward you. It dissipates in the air before it grab hold.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  3 /* Death */,   0.04, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'As the Paradox ceases an ominous voice sunders the air, "We have shed the yoke of leaders that cannot see the divine glory of reliance upon the self. Soon other observers, like myself shall reach this elightenment and our war shall bridge the distance from here to the Seat of the Singularity!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  3 /* Death */,  0.041, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, '"One voice, no more. One vision, no longer. A thousand hosts upon the world shall spread like the thundering tide. Chaos shall sweep where once order stood. Entropy will swallow creation and all will be cast in the shadow of eternal darkness. Our way is pure, our way is the relevance of the coming dark, our way is the way of sweltering heat when the sun shall rise no more and the moons cease their passing in the sky."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (23570, 16 /* KillTaunt */,  0.001, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, '"Your soul creeps away for another day. But soon it shall be claimed in the name of the sheltering dark."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (23570, 9,  7604,  0, 0, 0.04, False) /* Create Yellow Jewel (7604) for ContainTreasure */
+     , (23570, 9,     0,  0, 0, 0.96, False) /* Create nothing for ContainTreasure */
+     , (23570, 9,  9292,  0, 0, 0.06, False) /* Create Virindi Singularity Key (9292) for ContainTreasure */
+     , (23570, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
+     , (23570, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (23570, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (23570, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (23570, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/24574 Pagrok the Stone Collector - collectorstonecandethkeep - Level 96.sql
+++ b/Content/sql/weenies/24574 Pagrok the Stone Collector - collectorstonecandethkeep - Level 96.sql
@@ -1,0 +1,635 @@
+DELETE FROM `weenie` WHERE `class_Id` = 24574;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (24574, 'collectorstonecandethkeep', 10, '2020-05-14 05:20:19') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (24574,   1,         16) /* ItemType - Creature */
+     , (24574,   2,          5) /* CreatureType - Lugian */
+     , (24574,   3,         19) /* PaletteTemplate - Copper */
+     , (24574,   6,         -1) /* ItemsCapacity */
+     , (24574,   7,         -1) /* ContainersCapacity */
+     , (24574,   8,        120) /* Mass */
+     , (24574,  16,         32) /* ItemUseable - Remote */
+     , (24574,  25,         96) /* Level */
+     , (24574,  27,          0) /* ArmorType - None */
+     , (24574,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (24574,  95,          8) /* RadarBlipColor - Yellow */
+     , (24574, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (24574, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (24574, 146,        181) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (24574,   1, True ) /* Stuck */
+     , (24574,   8, True ) /* AllowGive */
+     , (24574,  12, True ) /* ReportCollisions */
+     , (24574,  13, False) /* Ethereal */
+     , (24574,  19, False) /* Attackable */
+     , (24574,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (24574,  42, True ) /* AllowEdgeSlide */
+     , (24574,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (24574,   1,       5) /* HeartbeatInterval */
+     , (24574,   2,       0) /* HeartbeatTimestamp */
+     , (24574,   3,    0.16) /* HealthRate */
+     , (24574,   4,       5) /* StaminaRate */
+     , (24574,   5,       1) /* ManaRate */
+     , (24574,  11,     300) /* ResetInterval */
+     , (24574,  12,     0.5) /* Shade */
+     , (24574,  13,     0.9) /* ArmorModVsSlash */
+     , (24574,  14,       1) /* ArmorModVsPierce */
+     , (24574,  15,     1.1) /* ArmorModVsBludgeon */
+     , (24574,  16,     0.4) /* ArmorModVsCold */
+     , (24574,  17,     0.4) /* ArmorModVsFire */
+     , (24574,  18,       1) /* ArmorModVsAcid */
+     , (24574,  19,     0.6) /* ArmorModVsElectric */
+     , (24574,  54,       3) /* UseRadius */
+     , (24574,  64,       1) /* ResistSlash */
+     , (24574,  65,       1) /* ResistPierce */
+     , (24574,  66,       1) /* ResistBludgeon */
+     , (24574,  67,       1) /* ResistFire */
+     , (24574,  68,       1) /* ResistCold */
+     , (24574,  69,       1) /* ResistAcid */
+     , (24574,  70,       1) /* ResistElectric */
+     , (24574,  71,       1) /* ResistHealthBoost */
+     , (24574,  72,       1) /* ResistStaminaDrain */
+     , (24574,  73,       1) /* ResistStaminaBoost */
+     , (24574,  74,       1) /* ResistManaDrain */
+     , (24574,  75,       1) /* ResistManaBoost */
+     , (24574, 104,      10) /* ObviousRadarRange */
+     , (24574, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (24574,   1, 'Pagrok the Stone Collector') /* Name */
+     , (24574,   5, 'Trophy Collector') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (24574,   1, 0x02000A0B) /* Setup */
+     , (24574,   2, 0x09000006) /* MotionTable */
+     , (24574,   3, 0x2000000A) /* SoundTable */
+     , (24574,   4, 0x30000003) /* CombatTable */
+     , (24574,   6, 0x040010C6) /* PaletteBase */
+     , (24574,   7, 0x1000047A) /* ClothingBase */
+     , (24574,   8, 0x06001037) /* Icon */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (24574,   1,  80, 0, 0) /* Strength */
+     , (24574,   2,  70, 0, 0) /* Endurance */
+     , (24574,   3,  70, 0, 0) /* Quickness */
+     , (24574,   4,  65, 0, 0) /* Coordination */
+     , (24574,   5,  50, 0, 0) /* Focus */
+     , (24574,   6,  50, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (24574,   1,    80, 0, 0, 115) /* MaxHealth */
+     , (24574,   3,   120, 0, 0, 190) /* MaxStamina */
+     , (24574,   5,    50, 0, 0, 100) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (24574,  1, 0, 2, 0,   1, 0, 0) /* Axe                 Trained */
+     , (24574,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
+     , (24574,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
+     , (24574, 12, 0, 2, 0,   0, 0, 0) /* ThrownWeapon        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (24574,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (24574,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (24574,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (24574,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (24574,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (24574,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (24574,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (24574,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (24574,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  1 /* Refuse */,      1, 27438 /* Head of the Homunculus */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'This looks like one of those Idol heads those crazy Vesayen mosswarts worship. Hmmm, it''s a lot smaller though. You could see if Grearrk, the mosswart living outside Sawato, knows anything about this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  5 /* HeartBeat */,  0.001, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Have you seen any strange black rocks or stones?  If you give me one, I will give you back a piece of it cut into the shape of a pretty gem.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  5 /* HeartBeat */,  0.002, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'I''m looking for various stones.  Not just any, but only from certain monsters.  I''ll also take swamp stones or banderling scalps.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  5 /* HeartBeat */,  0.003, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'I hear that obsidian comes from volcanoes, or from intense magical disruptions.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  5 /* HeartBeat */,  0.004, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'The great Obsidian Plain in the Direlands is quite a sight, but I do not like the feel of the place.  I hear it was caused by some kind of powerful magic.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  5 /* HeartBeat */,  0.005, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'I''ll also give you money for some of the trophy jewels you may have, but people tell me my prices aren''t very good.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3697 /* Red Jewel */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Very pretty.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1026, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 3500, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3696 /* Blue Gem */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Such a deep blue. A fine jewel.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1035, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 4000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3698 /* White Jewel */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Very nicely cut! I''ll take this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1044, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 2625 /* Trade Note (10,000) */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'A pleasure doing business.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 7604 /* Yellow Jewel */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'This is quite a fancy jewel!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1090, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 10000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 10000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  10 /* Tell */, 0, 1, NULL, 'I might be able to cut a gem like this given enough time...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3692 /* Black Stone */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Ah, yes, these make fine jewels.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1061, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 3717 /* Obsidian Jewel */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'Here is a finished one for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3717 /* Obsidian Jewel */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Ah, not a stone lover?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 2000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  10 /* Tell */, 0, 1, NULL, 'Take these then, everyone finds pyreal useful.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3686 /* Black Rock */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'I work these into perfect spheres.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1053, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 3720 /* Obsidian Sphere */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'Nice craftsmanship, eh?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 7399 /* Black Boulder */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'This is a very impressive rock! Here, take one that I''ve finished cutting and polishing.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1105, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 7469 /* Black Fire Atlan Stone */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'The light flickers in it''s facets like a black fire. Use that in an Empyrean Weapon.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3694 /* Swamp Stone */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Here''s what I make of those stones.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1011, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 3713 /* Swamp Gem */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3713 /* Swamp Gem */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'If you stare into the gems dark center for awhile you can almost make out... movement.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 1000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  10 /* Tell */, 0, 1, NULL, 'Haha, an unsettling optical illusion. Probably related to it''s magical properties.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3693 /* Banderling Scalp */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Oh good, a banderling scalp. Here, take this unpolished gem if you like.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1014, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 3933 /* Dull Gem */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'I cure these to make soft rags that I use to polish my stones and gems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3933 /* Dull Gem */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'You don''t want it? Well, ok, take some coin instead.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 1000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  10 /* Tell */, 0, 1, NULL, 'It may look dull now, but wait till I''m through with it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 11351 /* Mud Golem Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Yes, very good.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1009, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 1000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 11354 /* Water Golem Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'I have something for that.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1009, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 1250, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'Thank you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3673 /* Wood Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Golem hearts are fine.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1011, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 1250, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3670 /* Copper Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Good, good.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1039, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 3000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'Thank you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3671 /* Granite Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Granite? Yes, I need that.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1032, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 3500, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 3672 /* Iron Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Very pure Iron.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1035, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 4000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'My thanks.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 23201 /* Glacial Golem Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'This is a nice chunk of ice.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1053, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 2500, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'Thank you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+
+     INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 28520 /* Gold Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Impressive.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1061, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 6000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 9324 /* Obsidian Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Nice hunk of obsidian.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1061, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 6000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 7338 /* Diamond Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'You''re lucky to find one of these!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1095, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 7299 /* Diamond Scarab */, 3, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 23203 /* Pyreal Golem Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'A heart of pure pyreal!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1105, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 690 /* Pyreal Scarab */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'This is very valuable.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 23202 /* Platinum Golem Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'A heart of pure platinum!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1135, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 8897 /* Platinum Scarab */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'This is very valuable.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 11353 /* Vapor Golem Heart */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Not sure what to do with it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1110, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 2626 /* Trade Note (50,000) */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'Perhaps I''ll try cutting it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 12689 /* Diamond Powder */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Good for magic, but I can use it too.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1095, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 10000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 273 /* Pyreal */, 10000, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24467 /* Sunstone Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24467 /* Sunstone Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24468 /* Swordsman's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24468 /* Swordsman's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24460 /* Knifer's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24460 /* Knifer's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24462 /* Macer's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24462 /* Macer's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24458 /* Hatchetman's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24458 /* Hatchetman's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24465 /* Spearman's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24465 /* Spearman's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24464 /* Pugilist's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24464 /* Pugilist's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24466 /* Staffer's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24466 /* Staffer's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24455 /* Bowman's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24455 /* Bowman's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24456 /* Crossbowman's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24456 /* Crossbowman's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24469 /* Tosser's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24469 /* Tosser's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24457 /* Enchanter's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24457 /* Enchanter's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24459 /* Hieromancer's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24459 /* Hieromancer's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24454 /* Artificer's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24454 /* Artificer's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  6 /* Give */,      1, 24461 /* Life Giver's Gauntlets */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 1, 1, NULL, 'Ah, Sunstone is truly a beautiful gem. A shame that clumsy hands have marred it as such. I shall restore it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Pagrok pulls a few small vials of oil and a pair of fine chisels from a nearby pack. As he finishes the repairs, he polishes the gauntlets and hands them back to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 24461 /* Life Giver's Gauntlets */, 1, 14 /* Red */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (24574,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 1, 1, NULL, 'I will take a number of trophy stones and jewels, such as virindi jewels, swamp stones, iron, copper, and granite golem hearts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'I''ll also take banderling trophies.  But what I really specialize in are the rare black rocks, black stones, and the repair of Sunstone Gauntlets.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (24574, 2,  7580,  0, 0, 0, False) /* Create Pickaxe (7580) for Wield */;

--- a/Content/sql/weenies/25859 Biaka - margulbiaka - Level 161.sql
+++ b/Content/sql/weenies/25859 Biaka - margulbiaka - Level 161.sql
@@ -1,0 +1,184 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25859;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25859, 'margulbiaka', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25859,   1,         16) /* ItemType - Creature */
+     , (25859,   2,         71) /* CreatureType - Margul */
+     , (25859,   3,         21) /* PaletteTemplate - Gold */
+     , (25859,   6,         -1) /* ItemsCapacity */
+     , (25859,   7,         -1) /* ContainersCapacity */
+     , (25859,  16,          1) /* ItemUseable - No */
+     , (25859,  25,        161) /* Level */
+     , (25859,  27,          0) /* ArmorType - None */
+     , (25859,  40,          2) /* CombatMode - Melee */
+     , (25859,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (25859,  72,         22) /* FriendType - Shadow */
+     , (25859,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (25859, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (25859, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (25859, 140,          1) /* AiOptions - CanOpenDoors */
+     , (25859, 146,    1000000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25859,   1, True ) /* Stuck */
+     , (25859,   6, True ) /* AiUsesMana */
+     , (25859,  11, False) /* IgnoreCollisions */
+     , (25859,  12, True ) /* ReportCollisions */
+     , (25859,  13, False) /* Ethereal */
+     , (25859, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25859,   1,       5) /* HeartbeatInterval */
+     , (25859,   2,       0) /* HeartbeatTimestamp */
+     , (25859,   3,       8) /* HealthRate */
+     , (25859,   4,       3) /* StaminaRate */
+     , (25859,   5,       1) /* ManaRate */
+     , (25859,  12,     0.5) /* Shade */
+     , (25859,  13,    1.05) /* ArmorModVsSlash */
+     , (25859,  14,       1) /* ArmorModVsPierce */
+     , (25859,  15,    0.95) /* ArmorModVsBludgeon */
+     , (25859,  16,    0.95) /* ArmorModVsCold */
+     , (25859,  17,     1.2) /* ArmorModVsFire */
+     , (25859,  18,     1.2) /* ArmorModVsAcid */
+     , (25859,  19,    0.95) /* ArmorModVsElectric */
+     , (25859,  31,      24) /* VisualAwarenessRange */
+     , (25859,  34,       1) /* PowerupTime */
+     , (25859,  36,       1) /* ChargeSpeed */
+     , (25859,  39,     0.6) /* DefaultScale */
+     , (25859,  64,    0.85) /* ResistSlash */
+     , (25859,  65,    0.85) /* ResistPierce */
+     , (25859,  66,    0.95) /* ResistBludgeon */
+     , (25859,  67,    0.75) /* ResistFire */
+     , (25859,  68,    0.95) /* ResistCold */
+     , (25859,  69,    0.75) /* ResistAcid */
+     , (25859,  70,    0.95) /* ResistElectric */
+     , (25859,  71,       1) /* ResistHealthBoost */
+     , (25859,  72,       1) /* ResistStaminaDrain */
+     , (25859,  73,       1) /* ResistStaminaBoost */
+     , (25859,  74,       1) /* ResistManaDrain */
+     , (25859,  75,       1) /* ResistManaBoost */
+     , (25859,  80,       2) /* AiUseMagicDelay */
+     , (25859, 104,      10) /* ObviousRadarRange */
+     , (25859, 122,       2) /* AiAcquireHealth */
+     , (25859, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25859,   1, 'Biaka') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25859,   1, 0x0200101A) /* Setup */
+     , (25859,   2, 0x0900013F) /* MotionTable */
+     , (25859,   3, 0x200000A8) /* SoundTable */
+     , (25859,   4, 0x3000003A) /* CombatTable */
+     , (25859,   6, 0x040016E8) /* PaletteBase */
+     , (25859,   7, 0x100004FD) /* ClothingBase */
+     , (25859,   8, 0x0600304D) /* Icon */
+     , (25859,  22, 0x340000A9) /* PhysicsEffectTable */
+     , (25859,  30,         85) /* PhysicsScript - BreatheFrost */
+     , (25859,  35,         26) /* DeathTreasureType - T6_Boss_MedAmount - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (25859,   1, 420, 0, 0) /* Strength */
+     , (25859,   2, 500, 0, 0) /* Endurance */
+     , (25859,   3, 420, 0, 0) /* Quickness */
+     , (25859,   4, 450, 0, 0) /* Coordination */
+     , (25859,   5, 400, 0, 0) /* Focus */
+     , (25859,   6, 400, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (25859,   1,  7250, 0, 0, 7500) /* MaxHealth */
+     , (25859,   3,  7000, 0, 0, 7500) /* MaxStamina */
+     , (25859,   5,  7100, 0, 0, 7500) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (25859,  2, 0, 2, 0,   0, 0, 0) /* Bow                 Trained */
+     , (25859,  6, 0, 3, 0, 287, 0, 0) /* MeleeDefense        Specialized */
+     , (25859,  7, 0, 3, 0, 420, 0, 0) /* MissileDefense      Specialized */
+     , (25859,  9, 0, 3, 0, 270, 0, 0) /* Spear               Specialized */
+     , (25859, 15, 0, 3, 0, 285, 0, 0) /* MagicDefense        Specialized */
+     , (25859, 31, 0, 3, 0, 205, 0, 0) /* CreatureEnchantment Specialized */
+     , (25859, 32, 0, 3, 0, 205, 0, 0) /* ItemEnchantment     Specialized */
+     , (25859, 33, 0, 3, 0, 205, 0, 0) /* LifeMagic           Specialized */
+     , (25859, 34, 0, 3, 0, 205, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (25859,  0,  2, 165, 0.75,  650,  682,  650,  618,  618,  780,  780,  618,    0, 1,  0.4,  0.1,    0,  0.4,  0.1,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (25859, 10,  1, 165, 0.75,  650,  682,  650,  618,  618,  780,  780,  618,    0, 3,    0,  0.2,  0.8,    0,  0.2,  0.8,    0,    0,    0,    0,    0,    0) /* FrontLeg */
+     , (25859, 13,  1, 165, 0.75,  650,  682,  650,  618,  618,  780,  780,  618,    0, 3,    0,    0,    0,    0,    0,    0,  0.1,  0.3,  0.7,  0.1,  0.3,  0.7) /* RearLeg */
+     , (25859, 16,  4,  0,    0,  650,  682,  650,  618,  618,  780,  780,  618,    0, 2,  0.6,  0.7,  0.2,  0.6,  0.7,  0.2,  0.9,  0.7,  0.3,  0.9,  0.7,  0.3) /* Torso */
+     , (25859, 22,  8, 75,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (25859,   574,   2.01)  /* Creature Enchantment Ineptitude Other VI */
+     , (25859,   628,   2.01)  /* Life Magic Ineptitude Other VI */
+     , (25859,   652,   2.01)  /* War Magic Ineptitude Other VI */
+     , (25859,  1555,  2.005)  /* Blade Lure IV */
+     , (25859,  1609,  2.005)  /* Lure Blade IV */
+     , (25859,  1619,  2.005)  /* Blood Loather IV */
+     , (25859,  1631,  2.005)  /* Leaden Weapon IV */
+     , (25859,  2074,   2.03)  /* Gossamer Flesh */
+     , (25859,  2122,   2.04)  /* Disintegration */
+     , (25859,  2128,   2.04)  /* Ilservian's Flame */
+     , (25859,  2162,   2.02)  /* Olthoi's Gift */
+     , (25859,  2170,   2.02)  /* Inferno's Gift */
+     , (25859,  2318,   2.02)  /* Gravity Well */
+     , (25859,  2717,   2.04)  /* Acid Arc VII */
+     , (25859,  2745,   2.04)  /* Flame Arc VII */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (25859,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (25859, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25859,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25859,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25859,  5 /* HeartBeat */,  0.055, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25859,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25859,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25859,  5 /* HeartBeat */,  0.055, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (25859, 9, 30823,  0, 0, 0.05, False) /* Create Broken Black Marrow Key (30823) for ContainTreasure */
+     , (25859, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/25863 Hellion - margulhellion - Level 155.sql
+++ b/Content/sql/weenies/25863 Hellion - margulhellion - Level 155.sql
@@ -1,0 +1,184 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25863;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25863, 'margulhellion', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25863,   1,         16) /* ItemType - Creature */
+     , (25863,   2,         71) /* CreatureType - Margul */
+     , (25863,   3,         19) /* PaletteTemplate - Copper */
+     , (25863,   6,         -1) /* ItemsCapacity */
+     , (25863,   7,         -1) /* ContainersCapacity */
+     , (25863,  16,          1) /* ItemUseable - No */
+     , (25863,  25,        155) /* Level */
+     , (25863,  27,          0) /* ArmorType - None */
+     , (25863,  40,          2) /* CombatMode - Melee */
+     , (25863,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (25863,  72,         22) /* FriendType - Shadow */
+     , (25863,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (25863, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (25863, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (25863, 140,          1) /* AiOptions - CanOpenDoors */
+     , (25863, 146,     750000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25863,   1, True ) /* Stuck */
+     , (25863,   6, True ) /* AiUsesMana */
+     , (25863,  11, False) /* IgnoreCollisions */
+     , (25863,  12, True ) /* ReportCollisions */
+     , (25863,  13, False) /* Ethereal */
+     , (25863, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25863,   1,       5) /* HeartbeatInterval */
+     , (25863,   2,       0) /* HeartbeatTimestamp */
+     , (25863,   3,       6) /* HealthRate */
+     , (25863,   4,       3) /* StaminaRate */
+     , (25863,   5,       1) /* ManaRate */
+     , (25863,  12,     0.5) /* Shade */
+     , (25863,  13,    1.05) /* ArmorModVsSlash */
+     , (25863,  14,       1) /* ArmorModVsPierce */
+     , (25863,  15,    0.95) /* ArmorModVsBludgeon */
+     , (25863,  16,    0.95) /* ArmorModVsCold */
+     , (25863,  17,     1.2) /* ArmorModVsFire */
+     , (25863,  18,     1.2) /* ArmorModVsAcid */
+     , (25863,  19,    0.95) /* ArmorModVsElectric */
+     , (25863,  31,      24) /* VisualAwarenessRange */
+     , (25863,  34,       1) /* PowerupTime */
+     , (25863,  36,       1) /* ChargeSpeed */
+     , (25863,  39,     0.6) /* DefaultScale */
+     , (25863,  64,    0.85) /* ResistSlash */
+     , (25863,  65,    0.85) /* ResistPierce */
+     , (25863,  66,    0.95) /* ResistBludgeon */
+     , (25863,  67,    0.75) /* ResistFire */
+     , (25863,  68,    0.95) /* ResistCold */
+     , (25863,  69,    0.75) /* ResistAcid */
+     , (25863,  70,    0.95) /* ResistElectric */
+     , (25863,  71,       1) /* ResistHealthBoost */
+     , (25863,  72,       1) /* ResistStaminaDrain */
+     , (25863,  73,       1) /* ResistStaminaBoost */
+     , (25863,  74,       1) /* ResistManaDrain */
+     , (25863,  75,       1) /* ResistManaBoost */
+     , (25863,  80,       2) /* AiUseMagicDelay */
+     , (25863, 104,      10) /* ObviousRadarRange */
+     , (25863, 122,       2) /* AiAcquireHealth */
+     , (25863, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25863,   1, 'Hellion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25863,   1, 0x0200101A) /* Setup */
+     , (25863,   2, 0x0900013F) /* MotionTable */
+     , (25863,   3, 0x200000A8) /* SoundTable */
+     , (25863,   4, 0x3000003A) /* CombatTable */
+     , (25863,   6, 0x040016E8) /* PaletteBase */
+     , (25863,   7, 0x100004FD) /* ClothingBase */
+     , (25863,   8, 0x0600304D) /* Icon */
+     , (25863,  22, 0x340000A9) /* PhysicsEffectTable */
+     , (25863,  30,         84) /* PhysicsScript - BreatheFlame */
+     , (25863,  35,        461) /* DeathTreasureType - T6_Magic - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (25863,   1, 400, 0, 0) /* Strength */
+     , (25863,   2, 480, 0, 0) /* Endurance */
+     , (25863,   3, 400, 0, 0) /* Quickness */
+     , (25863,   4, 400, 0, 0) /* Coordination */
+     , (25863,   5, 380, 0, 0) /* Focus */
+     , (25863,   6, 380, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (25863,   1,  5760, 0, 0, 6000) /* MaxHealth */
+     , (25863,   3,  5520, 0, 0, 6000) /* MaxStamina */
+     , (25863,   5,  5620, 0, 0, 6000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (25863,  1, 0, 3, 0, 280, 0, 0) /* Axe                 Specialized */
+     , (25863,  2, 0, 2, 0,   0, 0, 0) /* Bow                 Trained */
+     , (25863,  6, 0, 3, 0, 305, 0, 0) /* MeleeDefense        Specialized */
+     , (25863,  7, 0, 3, 0, 426, 0, 0) /* MissileDefense      Specialized */
+     , (25863, 15, 0, 3, 0, 288, 0, 0) /* MagicDefense        Specialized */
+     , (25863, 31, 0, 3, 0, 205, 0, 0) /* CreatureEnchantment Specialized */
+     , (25863, 32, 0, 3, 0, 205, 0, 0) /* ItemEnchantment     Specialized */
+     , (25863, 33, 0, 3, 0, 205, 0, 0) /* LifeMagic           Specialized */
+     , (25863, 34, 0, 3, 0, 205, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (25863,  0,  2, 160, 0.75,  600,  630,  600,  570,  570,  720,  720,  570,    0, 1,  0.4,  0.1,    0,  0.4,  0.1,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (25863, 10,  1, 160, 0.75,  600,  630,  600,  570,  570,  720,  720,  570,    0, 3,    0,  0.2,  0.8,    0,  0.2,  0.8,    0,    0,    0,    0,    0,    0) /* FrontLeg */
+     , (25863, 13,  1, 160, 0.75,  600,  630,  600,  570,  570,  720,  720,  570,    0, 3,    0,    0,    0,    0,    0,    0,  0.1,  0.3,  0.7,  0.1,  0.3,  0.7) /* RearLeg */
+     , (25863, 16,  4,  0,    0,  600,  630,  600,  570,  570,  720,  720,  570,    0, 2,  0.6,  0.7,  0.2,  0.6,  0.7,  0.2,  0.9,  0.7,  0.3,  0.9,  0.7,  0.3) /* Torso */
+     , (25863, 22, 16, 145,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (25863,    63,   2.04)  /* Acid Stream VI */
+     , (25863,    85,   2.04)  /* Flame Bolt VI */
+     , (25863,   574,   2.01)  /* Creature Enchantment Ineptitude Other VI */
+     , (25863,   628,   2.01)  /* Life Magic Ineptitude Other VI */
+     , (25863,   652,   2.01)  /* War Magic Ineptitude Other VI */
+     , (25863,  1555,  2.005)  /* Blade Lure IV */
+     , (25863,  1609,  2.005)  /* Lure Blade IV */
+     , (25863,  1619,  2.005)  /* Blood Loather IV */
+     , (25863,  1631,  2.005)  /* Leaden Weapon IV */
+     , (25863,  2074,   2.03)  /* Gossamer Flesh */
+     , (25863,  2162,   2.02)  /* Olthoi's Gift */
+     , (25863,  2170,   2.02)  /* Inferno's Gift */
+     , (25863,  2318,   2.02)  /* Gravity Well */
+     , (25863,  2716,   2.04)  /* Acid Arc VI */
+     , (25863,  2744,   2.04)  /* Flame Arc VI */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (25863,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (25863, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25863,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25863,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25863,  5 /* HeartBeat */,  0.055, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25863,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25863,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25863,  5 /* HeartBeat */,  0.055, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (25863, 9, 30823,  0, 0, 0.05, False) /* Create Broken Black Marrow Key (30823) for ContainTreasure */
+     , (25863, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/28551 Sparkling Dual Fragment - crystaldualfragmentsparkling - Level 90.sql
+++ b/Content/sql/weenies/28551 Sparkling Dual Fragment - crystaldualfragmentsparkling - Level 90.sql
@@ -1,0 +1,136 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28551;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28551, 'crystaldualfragmentsparkling', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28551,   1,         16) /* ItemType - Creature */
+     , (28551,   2,         47) /* CreatureType - Crystal */
+     , (28551,   3,         13) /* PaletteTemplate - Purple */
+     , (28551,   6,         -1) /* ItemsCapacity */
+     , (28551,   7,         -1) /* ContainersCapacity */
+     , (28551,  16,          1) /* ItemUseable - No */
+     , (28551,  25,         90) /* Level */
+     , (28551,  27,          0) /* ArmorType - None */
+     , (28551,  40,          2) /* CombatMode - Melee */
+     , (28551,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (28551,  69,          4) /* CombatTactic - LastDamager */
+     , (28551,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (28551, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (28551, 146,      26500) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28551,   1, True ) /* Stuck */
+     , (28551,   6, True ) /* AiUsesMana */
+     , (28551,  11, False) /* IgnoreCollisions */
+     , (28551,  12, True ) /* ReportCollisions */
+     , (28551,  13, False) /* Ethereal */
+     , (28551,  15, True ) /* LightsStatus */
+     , (28551,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28551,   1,       5) /* HeartbeatInterval */
+     , (28551,   2,       0) /* HeartbeatTimestamp */
+     , (28551,   3,     0.7) /* HealthRate */
+     , (28551,   4,       5) /* StaminaRate */
+     , (28551,   5,       2) /* ManaRate */
+     , (28551,  12,     0.5) /* Shade */
+     , (28551,  13,       1) /* ArmorModVsSlash */
+     , (28551,  14,       1) /* ArmorModVsPierce */
+     , (28551,  15,       1) /* ArmorModVsBludgeon */
+     , (28551,  16,    1.19) /* ArmorModVsCold */
+     , (28551,  17,     100) /* ArmorModVsFire */
+     , (28551,  18,    2.78) /* ArmorModVsAcid */
+     , (28551,  19,       1) /* ArmorModVsElectric */
+     , (28551,  31,      12) /* VisualAwarenessRange */
+     , (28551,  34,       1) /* PowerupTime */
+     , (28551,  36,       1) /* ChargeSpeed */
+     , (28551,  39,     1.5) /* DefaultScale */
+     , (28551,  64,       1) /* ResistSlash */
+     , (28551,  65,       1) /* ResistPierce */
+     , (28551,  66,       1) /* ResistBludgeon */
+     , (28551,  67,       0) /* ResistFire */
+     , (28551,  68,    0.65) /* ResistCold */
+     , (28551,  69,     0.3) /* ResistAcid */
+     , (28551,  70,       1) /* ResistElectric */
+     , (28551,  71,       1) /* ResistHealthBoost */
+     , (28551,  72,       1) /* ResistStaminaDrain */
+     , (28551,  73,       1) /* ResistStaminaBoost */
+     , (28551,  74,       1) /* ResistManaDrain */
+     , (28551,  75,       1) /* ResistManaBoost */
+     , (28551,  80,       2) /* AiUseMagicDelay */
+     , (28551, 104,      10) /* ObviousRadarRange */
+     , (28551, 122,       2) /* AiAcquireHealth */
+     , (28551, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28551,   1, 'Sparkling Dual Fragment') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28551,   1, 0x020008FA) /* Setup */
+     , (28551,   2, 0x09000099) /* MotionTable */
+     , (28551,   3, 0x20000059) /* SoundTable */
+     , (28551,   4, 0x30000027) /* CombatTable */
+     , (28551,   6, 0x04000BEF) /* PaletteBase */
+     , (28551,   7, 0x10000193) /* ClothingBase */
+     , (28551,   8, 0x06001BBB) /* Icon */
+     , (28551,  22, 0x34000074) /* PhysicsEffectTable */
+     , (28551,  35,        462) /* DeathTreasureType - T3_Magic - Loot Tier: 3 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (28551,   1, 160, 0, 0) /* Strength */
+     , (28551,   2, 200, 0, 0) /* Endurance */
+     , (28551,   3, 175, 0, 0) /* Quickness */
+     , (28551,   4, 175, 0, 0) /* Coordination */
+     , (28551,   5, 180, 0, 0) /* Focus */
+     , (28551,   6, 200, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (28551,   1,   280, 0, 0, 380) /* MaxHealth */
+     , (28551,   3,   200, 0, 0, 400) /* MaxStamina */
+     , (28551,   5,   200, 0, 0, 400) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (28551,  2, 0, 2, 0,   0, 0, 0) /* Bow                 Trained */
+     , (28551,  6, 0, 3, 0, 293, 0, 0) /* MeleeDefense        Specialized */
+     , (28551,  7, 0, 3, 0, 390, 0, 0) /* MissileDefense      Specialized */
+     , (28551, 13, 0, 3, 0, 278, 0, 0) /* UnarmedCombat       Specialized */
+     , (28551, 15, 0, 3, 0, 211, 0, 0) /* MagicDefense        Specialized */
+     , (28551, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (28551, 24, 0, 2, 0,  10, 0, 0) /* Run                 Trained */
+     , (28551, 31, 0, 3, 0, 180, 0, 0) /* CreatureEnchantment Specialized */
+     , (28551, 33, 0, 3, 0, 180, 0, 0) /* LifeMagic           Specialized */
+     , (28551, 34, 0, 3, 0, 180, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (28551,  0,  4, 50, 0.75,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 1,  0.5,  0.2,    0,  0.5,  0.2,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (28551, 10,  4, 50,    0,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 2,  0.2,  0.4,  0.5,  0.2,  0.4,  0.5,    0,    0,    0,    0,    0,    0) /* FrontLeg */
+     , (28551, 12,  4, 50, 0.75,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 3,    0,    0, 0.25,    0,    0, 0.25,    0,    0,    0,    0,    0,    0) /* FrontFoot */
+     , (28551, 13,  4, 50,    0,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 2,    0,    0,    0,    0,    0,    0,  0.3,  0.4,  0.5,  0.3,  0.4,  0.5) /* RearLeg */
+     , (28551, 15,  4, 50, 0.75,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0, 0.25,    0,    0, 0.25) /* RearFoot */
+     , (28551, 16,  4, 50,    0,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 2,  0.3,  0.4, 0.25,  0.3,  0.4, 0.25,  0.6,  0.5, 0.25,  0.6,  0.5, 0.25) /* Torso */
+     , (28551, 17,  4, 50, 0.75,  170,  170,  170,  170,  202, 17000,  473,  170,    0, 2,    0,    0,    0,    0,    0,    0,  0.1,  0.1,    0,  0.1,  0.1,    0) /* Tail */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (28551,    83,  2.115)  /* Flame Bolt IV */
+     , (28551,    84,  2.031)  /* Flame Bolt V */
+     , (28551,   168,  2.032)  /* Regeneration Self IV */
+     , (28551,   277,  2.032)  /* Magic Resistance Self IV */
+     , (28551,   283,  2.042)  /* Magic Yield Other IV */
+     , (28551,   608,  2.032)  /* Life Magic Mastery Self IV */
+     , (28551,   626,  2.042)  /* Life Magic Ineptitude Other IV */
+     , (28551,   656,  2.032)  /* Mana Conversion Mastery Self IV */
+     , (28551,  1106,  2.042)  /* Fire Vulnerability Other IV */
+     , (28551,  1158,   2.04)  /* Heal Self III */
+     , (28551,  1174,  2.042)  /* Harm Other IV */
+     , (28551,  1240,  2.042)  /* Drain Health Other IV */
+     , (28551,  1310,   2.04)  /* Armor Self IV */
+     , (28551,  1419,  2.042)  /* Slowness Other V */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (28551,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (28551, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (28551, 9,  6056,  0, 0, 0.02, False) /* Create Small Shard (6056) for ContainTreasure */
+     , (28551, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30680 Withered Drudge Seraph - drudgeseraphwithered - Level 161.sql
+++ b/Content/sql/weenies/30680 Withered Drudge Seraph - drudgeseraphwithered - Level 161.sql
@@ -1,0 +1,208 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30680;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30680, 'drudgeseraphwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30680,   1,         16) /* ItemType - Creature */
+     , (30680,   2,          3) /* CreatureType - Drudge */
+     , (30680,   3,         88) /* PaletteTemplate - DyeWinterBlue */
+     , (30680,   6,         -1) /* ItemsCapacity */
+     , (30680,   7,         -1) /* ContainersCapacity */
+     , (30680,  16,          1) /* ItemUseable - No */
+     , (30680,  25,        161) /* Level */
+     , (30680,  27,          0) /* ArmorType - None */
+     , (30680,  40,          2) /* CombatMode - Melee */
+     , (30680,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (30680,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30680, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (30680, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (30680, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30680, 146,     303487) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30680,   1, True ) /* Stuck */
+     , (30680,  11, False) /* IgnoreCollisions */
+     , (30680,  12, True ) /* ReportCollisions */
+     , (30680,  13, False) /* Ethereal */
+     , (30680, 103, True ) /* NonProjectileMagicImmune */
+     , (30680, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30680,   1,       5) /* HeartbeatInterval */
+     , (30680,   2,       0) /* HeartbeatTimestamp */
+     , (30680,   3,      12) /* HealthRate */
+     , (30680,   4,      25) /* StaminaRate */
+     , (30680,   5,       1) /* ManaRate */
+     , (30680,  12,     0.5) /* Shade */
+     , (30680,  13,    0.85) /* ArmorModVsSlash */
+     , (30680,  14,    0.45) /* ArmorModVsPierce */
+     , (30680,  15,    0.85) /* ArmorModVsBludgeon */
+     , (30680,  16,    0.75) /* ArmorModVsCold */
+     , (30680,  17,    0.85) /* ArmorModVsFire */
+     , (30680,  18,    0.75) /* ArmorModVsAcid */
+     , (30680,  19,     0.9) /* ArmorModVsElectric */
+     , (30680,  31,      18) /* VisualAwarenessRange */
+     , (30680,  34,       1) /* PowerupTime */
+     , (30680,  36,       1) /* ChargeSpeed */
+     , (30680,  39,     1.5) /* DefaultScale */
+     , (30680,  64,    0.85) /* ResistSlash */
+     , (30680,  65,    0.55) /* ResistPierce */
+     , (30680,  66,     0.9) /* ResistBludgeon */
+     , (30680,  67,     1.9) /* ResistFire */
+     , (30680,  68,    0.85) /* ResistCold */
+     , (30680,  69,    0.85) /* ResistAcid */
+     , (30680,  70,    0.15) /* ResistElectric */
+     , (30680,  71,       1) /* ResistHealthBoost */
+     , (30680,  72,       1) /* ResistStaminaDrain */
+     , (30680,  73,       1) /* ResistStaminaBoost */
+     , (30680,  74,       1) /* ResistManaDrain */
+     , (30680,  75,       1) /* ResistManaBoost */
+     , (30680, 104,      10) /* ObviousRadarRange */
+     , (30680, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30680,   1, 'Withered Drudge Seraph') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30680,   1, 0x020012B2) /* Setup */
+     , (30680,   2, 0x09000008) /* MotionTable */
+     , (30680,   3, 0x20000007) /* SoundTable */
+     , (30680,   4, 0x30000004) /* CombatTable */
+     , (30680,   6, 0x04000F6C) /* PaletteBase */
+     , (30680,   7, 0x100005A0) /* ClothingBase */
+     , (30680,   8, 0x06001035) /* Icon */
+     , (30680,  22, 0x3400001A) /* PhysicsEffectTable */
+     , (30680,  32,        423) /* WieldedTreasureType */
+     , (30680,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30680,   1, 440, 0, 0) /* Strength */
+     , (30680,   2, 360, 0, 0) /* Endurance */
+     , (30680,   3, 360, 0, 0) /* Quickness */
+     , (30680,   4, 360, 0, 0) /* Coordination */
+     , (30680,   5, 400, 0, 0) /* Focus */
+     , (30680,   6, 400, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30680,   1,  5680, 0, 0, 5860) /* MaxHealth */
+     , (30680,   3,  4640, 0, 0, 5000) /* MaxStamina */
+     , (30680,   5,  4600, 0, 0, 5000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30680,  1, 0, 3, 0, 275, 0, 0) /* Axe                 Specialized */
+     , (30680,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
+     , (30680,  7, 0, 3, 0, 445, 0, 0) /* MissileDefense      Specialized */
+     , (30680, 12, 0, 3, 0, 240, 0, 0) /* ThrownWeapon        Specialized */
+     , (30680, 14, 0, 3, 0, 350, 0, 0) /* ArcaneLore          Specialized */
+     , (30680, 15, 0, 3, 0, 276, 0, 0) /* MagicDefense        Specialized */
+     , (30680, 20, 0, 3, 0, 120, 0, 0) /* Deception           Specialized */
+     , (30680, 24, 0, 3, 0,  75, 0, 0) /* Run                 Specialized */
+     , (30680, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment Specialized */
+     , (30680, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
+     , (30680, 34, 0, 3, 0, 200, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30680,  0,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30680,  1,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30680,  2,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30680,  3,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30680,  4,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30680,  5,  4, 60, 0.75,  360,  306,  162,  306,  270,  306,  270,  324,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30680,  6,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30680,  7,  4,  0,    0,  360,  306,  162,  306,  270,  306,  270,  324,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30680,  8,  4, 80, 0.75,  360,  306,  162,  306,  270,  306,  270,  324,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (30680,    80,  2.011)  /* Lightning Bolt VI */
+     , (30680,  1089,  2.011)  /* Lightning Vulnerability Other VI */
+     , (30680,  1161,  2.011)  /* Heal Self VI */
+     , (30680,  1242,  2.011)  /* Drain Health Other VI */
+     , (30680,  1325,  2.011)  /* Imperil Other IV */
+     , (30680,  2056,  2.011)  /* Ataxia */
+     , (30680,  2064,  2.011)  /* Self Loathing */
+     , (30680,  2140,  2.011)  /* Alset's Coil */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30680,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30680, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,   0.07, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,   0.07, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30680,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30680, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30680, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30680, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30680, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */
+     , (30680, 9,  3669,  0, 0, 0.03, False) /* Create Drudge Charm (3669) for ContainTreasure */
+     , (30680, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30682 Withered Drudge Seraph Mystic - drudgemysticwithered - Level 165.sql
+++ b/Content/sql/weenies/30682 Withered Drudge Seraph Mystic - drudgemysticwithered - Level 165.sql
@@ -1,0 +1,207 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30682;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30682, 'drudgemysticwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30682,   1,         16) /* ItemType - Creature */
+     , (30682,   2,          3) /* CreatureType - Drudge */
+     , (30682,   3,          5) /* PaletteTemplate - DarkBlue */
+     , (30682,   6,         -1) /* ItemsCapacity */
+     , (30682,   7,         -1) /* ContainersCapacity */
+     , (30682,  16,          1) /* ItemUseable - No */
+     , (30682,  25,        165) /* Level */
+     , (30682,  27,          0) /* ArmorType - None */
+     , (30682,  40,          2) /* CombatMode - Melee */
+     , (30682,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (30682,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30682, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (30682, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (30682, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30682, 146,     385880) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30682,   1, True ) /* Stuck */
+     , (30682,  11, False) /* IgnoreCollisions */
+     , (30682,  12, True ) /* ReportCollisions */
+     , (30682,  13, False) /* Ethereal */
+     , (30682, 103, True ) /* NonProjectileMagicImmune */
+     , (30682, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30682,   1,       5) /* HeartbeatInterval */
+     , (30682,   2,       0) /* HeartbeatTimestamp */
+     , (30682,   3,      12) /* HealthRate */
+     , (30682,   4,      25) /* StaminaRate */
+     , (30682,   5,       1) /* ManaRate */
+     , (30682,  12,     0.5) /* Shade */
+     , (30682,  13,    1.05) /* ArmorModVsSlash */
+     , (30682,  14,       1) /* ArmorModVsPierce */
+     , (30682,  15,    1.05) /* ArmorModVsBludgeon */
+     , (30682,  16,    0.95) /* ArmorModVsCold */
+     , (30682,  17,    1.05) /* ArmorModVsFire */
+     , (30682,  18,    0.75) /* ArmorModVsAcid */
+     , (30682,  19,       1) /* ArmorModVsElectric */
+     , (30682,  31,      18) /* VisualAwarenessRange */
+     , (30682,  34,       1) /* PowerupTime */
+     , (30682,  36,       1) /* ChargeSpeed */
+     , (30682,  39,     1.5) /* DefaultScale */
+     , (30682,  64,    0.75) /* ResistSlash */
+     , (30682,  65,    0.75) /* ResistPierce */
+     , (30682,  66,    0.75) /* ResistBludgeon */
+     , (30682,  67,     0.8) /* ResistFire */
+     , (30682,  68,    0.65) /* ResistCold */
+     , (30682,  69,     1.8) /* ResistAcid */
+     , (30682,  70,    0.35) /* ResistElectric */
+     , (30682,  71,       1) /* ResistHealthBoost */
+     , (30682,  72,       1) /* ResistStaminaDrain */
+     , (30682,  73,       1) /* ResistStaminaBoost */
+     , (30682,  74,       1) /* ResistManaDrain */
+     , (30682,  75,       1) /* ResistManaBoost */
+     , (30682, 104,      10) /* ObviousRadarRange */
+     , (30682, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30682,   1, 'Withered Drudge Seraph Mystic') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30682,   1, 0x020012B2) /* Setup */
+     , (30682,   2, 0x09000008) /* MotionTable */
+     , (30682,   3, 0x20000007) /* SoundTable */
+     , (30682,   4, 0x30000004) /* CombatTable */
+     , (30682,   6, 0x04000F6C) /* PaletteBase */
+     , (30682,   7, 0x100005A0) /* ClothingBase */
+     , (30682,   8, 0x06001035) /* Icon */
+     , (30682,  22, 0x3400001A) /* PhysicsEffectTable */
+     , (30682,  35,         26) /* DeathTreasureType - T6_Boss_MedAmount - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30682,   1, 450, 0, 0) /* Strength */
+     , (30682,   2, 400, 0, 0) /* Endurance */
+     , (30682,   3, 380, 0, 0) /* Quickness */
+     , (30682,   4, 380, 0, 0) /* Coordination */
+     , (30682,   5, 420, 0, 0) /* Focus */
+     , (30682,   6, 420, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30682,   1,  5800, 0, 0, 6000) /* MaxHealth */
+     , (30682,   3,  5600, 0, 0, 6000) /* MaxStamina */
+     , (30682,   5,  5580, 0, 0, 6000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30682,  1, 0, 3, 0, 282, 0, 0) /* Axe                 Specialized */
+     , (30682,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
+     , (30682,  7, 0, 3, 0, 445, 0, 0) /* MissileDefense      Specialized */
+     , (30682, 12, 0, 3, 0, 215, 0, 0) /* ThrownWeapon        Specialized */
+     , (30682, 14, 0, 3, 0, 350, 0, 0) /* ArcaneLore          Specialized */
+     , (30682, 15, 0, 3, 0, 330, 0, 0) /* MagicDefense        Specialized */
+     , (30682, 20, 0, 3, 0, 120, 0, 0) /* Deception           Specialized */
+     , (30682, 24, 0, 3, 0,  75, 0, 0) /* Run                 Specialized */
+     , (30682, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment Specialized */
+     , (30682, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
+     , (30682, 34, 0, 3, 0, 200, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30682,  0,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30682,  1,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30682,  2,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30682,  3,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30682,  4,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30682,  5,  1, 120, 0.75,  550,  578,  550,  578,  523,  578,  413,  550,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30682,  6,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30682,  7,  4,  0,    0,  550,  578,  550,  578,  523,  578,  413,  550,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30682,  8,  4, 140, 0.75,  550,  578,  550,  578,  523,  578,  413,  550,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (30682,  1089,   2.05)  /* Lightning Vulnerability Other VI */
+     , (30682,  1161,   2.05)  /* Heal Self VI */
+     , (30682,  1326,   2.05)  /* Imperil Other V */
+     , (30682,  1420,   2.05)  /* Slowness Other VI */
+     , (30682,  1468,   2.05)  /* Feeblemind Other VI */
+     , (30682,  2122,   2.05)  /* Disintegration */
+     , (30682,  2123,   2.05)  /* Celdiseth's Searing */
+     , (30682,  2140,   2.05)  /* Alset's Coil */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30682,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30682, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,   0.07, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,   0.07, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30682,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30682, 9, 23108,  0, 0, 0.04, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30682, 9,     0,  0, 0, 0.96, False) /* Create nothing for ContainTreasure */
+     , (30682, 9, 23107,  0, 0, 0.02, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30682, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30682, 9, 25567,  0, 0, 0.1, False) /* Create Glittering Key (25567) for ContainTreasure */
+     , (30682, 9,     0,  0, 0, 0.9, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30683 Withered Banderling Hierophant - banderlingheirophantwithered - Level 161.sql
+++ b/Content/sql/weenies/30683 Withered Banderling Hierophant - banderlingheirophantwithered - Level 161.sql
@@ -1,0 +1,204 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30683;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30683, 'banderlingheirophantwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30683,   1,         16) /* ItemType - Creature */
+     , (30683,   2,          2) /* CreatureType - Banderling */
+     , (30683,   3,         76) /* PaletteTemplate - Orange */
+     , (30683,   6,         -1) /* ItemsCapacity */
+     , (30683,   7,         -1) /* ContainersCapacity */
+     , (30683,  16,          1) /* ItemUseable - No */
+     , (30683,  25,        161) /* Level */
+     , (30683,  27,          0) /* ArmorType - None */
+     , (30683,  40,          2) /* CombatMode - Melee */
+     , (30683,  68,          3) /* TargetingTactic - Random, Focused */
+     , (30683,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30683, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (30683, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (30683, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30683, 146,     317687) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30683,   1, True ) /* Stuck */
+     , (30683,   6, True ) /* AiUsesMana */
+     , (30683,  11, False) /* IgnoreCollisions */
+     , (30683,  12, True ) /* ReportCollisions */
+     , (30683,  13, False) /* Ethereal */
+     , (30683, 103, True ) /* NonProjectileMagicImmune */
+     , (30683, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30683,   1,       5) /* HeartbeatInterval */
+     , (30683,   2,       0) /* HeartbeatTimestamp */
+     , (30683,   3,      12) /* HealthRate */
+     , (30683,   4,      25) /* StaminaRate */
+     , (30683,   5,       2) /* ManaRate */
+     , (30683,  12,     0.5) /* Shade */
+     , (30683,  13,     0.5) /* ArmorModVsSlash */
+     , (30683,  14,    0.35) /* ArmorModVsPierce */
+     , (30683,  15,    0.55) /* ArmorModVsBludgeon */
+     , (30683,  16,     0.5) /* ArmorModVsCold */
+     , (30683,  17,    0.85) /* ArmorModVsFire */
+     , (30683,  18,    0.35) /* ArmorModVsAcid */
+     , (30683,  19,     1.1) /* ArmorModVsElectric */
+     , (30683,  31,      22) /* VisualAwarenessRange */
+     , (30683,  34,       1) /* PowerupTime */
+     , (30683,  36,       1) /* ChargeSpeed */
+     , (30683,  39,     1.3) /* DefaultScale */
+     , (30683,  64,    0.75) /* ResistSlash */
+     , (30683,  65,    0.55) /* ResistPierce */
+     , (30683,  66,     0.5) /* ResistBludgeon */
+     , (30683,  67,    1.05) /* ResistFire */
+     , (30683,  68,    0.75) /* ResistCold */
+     , (30683,  69,    0.35) /* ResistAcid */
+     , (30683,  70,     2.5) /* ResistElectric */
+     , (30683,  71,       1) /* ResistHealthBoost */
+     , (30683,  72,       1) /* ResistStaminaDrain */
+     , (30683,  73,       1) /* ResistStaminaBoost */
+     , (30683,  74,       1) /* ResistManaDrain */
+     , (30683,  75,       1) /* ResistManaBoost */
+     , (30683,  80,       3) /* AiUseMagicDelay */
+     , (30683, 104,      10) /* ObviousRadarRange */
+     , (30683, 122,       2) /* AiAcquireHealth */
+     , (30683, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30683,   1, 'Withered Banderling Hierophant') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30683,   1, 0x020012B4) /* Setup */
+     , (30683,   2, 0x09000007) /* MotionTable */
+     , (30683,   3, 0x20000005) /* SoundTable */
+     , (30683,   4, 0x30000002) /* CombatTable */
+     , (30683,   6, 0x04001425) /* PaletteBase */
+     , (30683,   7, 0x100005A1) /* ClothingBase */
+     , (30683,   8, 0x0600103D) /* Icon */
+     , (30683,  22, 0x34000017) /* PhysicsEffectTable */
+     , (30683,  32,        423) /* WieldedTreasureType */
+     , (30683,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30683,   1, 260, 0, 0) /* Strength */
+     , (30683,   2, 300, 0, 0) /* Endurance */
+     , (30683,   3, 320, 0, 0) /* Quickness */
+     , (30683,   4, 320, 0, 0) /* Coordination */
+     , (30683,   5, 360, 0, 0) /* Focus */
+     , (30683,   6, 360, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30683,   1,  5850, 0, 0, 6000) /* MaxHealth */
+     , (30683,   3,  5700, 0, 0, 6000) /* MaxStamina */
+     , (30683,   5,  2640, 0, 0, 3000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30683,  2, 0, 3, 0, 290, 0, 0) /* Bow                 Specialized */
+     , (30683,  6, 0, 3, 0, 327, 0, 0) /* MeleeDefense        Specialized */
+     , (30683,  7, 0, 3, 0, 444, 0, 0) /* MissileDefense      Specialized */
+     , (30683, 13, 0, 3, 0, 283, 0, 0) /* UnarmedCombat       Specialized */
+     , (30683, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
+     , (30683, 15, 0, 3, 0, 350, 0, 0) /* MagicDefense        Specialized */
+     , (30683, 20, 0, 3, 0,  40, 0, 0) /* Deception           Specialized */
+     , (30683, 22, 0, 3, 0,  40, 0, 0) /* Jump                Specialized */
+     , (30683, 24, 0, 3, 0,  40, 0, 0) /* Run                 Specialized */
+     , (30683, 31, 0, 3, 0, 210, 0, 0) /* CreatureEnchantment Specialized */
+     , (30683, 33, 0, 3, 0, 210, 0, 0) /* LifeMagic           Specialized */
+     , (30683, 34, 0, 3, 0, 210, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30683,  0,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30683,  1,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30683,  2,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30683,  3,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30683,  4,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30683,  5,  4, 110, 0.75,  750,  375,  263,  413,  375,  638,  263,  825,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30683,  6,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30683,  7,  4,  0,    0,  750,  375,  263,  413,  375,  638,  263,  825,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30683,  8,  4, 130, 0.75,  750,  375,  263,  413,  375,  638,  263,  825,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (30683,    74,  2.071)  /* Frost Bolt VI */
+     , (30683,    85,  2.071)  /* Flame Bolt VI */
+     , (30683,   234,  2.071)  /* Vulnerability Other VI */
+     , (30683,   267,  2.071)  /* Defenselessness Other VI */
+     , (30683,   285,  2.071)  /* Magic Yield Other VI */
+     , (30683,  1161,   2.05)  /* Heal Self VI */
+     , (30683,  1176,   2.05)  /* Harm Other VI */
+     , (30683,  1241,   2.05)  /* Drain Health Other V */
+     , (30683,  2056,  2.071)  /* Ataxia */
+     , (30683,  2074,  2.071)  /* Gossamer Flesh */
+     , (30683,  2084,  2.071)  /* Belly of Lead */
+     , (30683,  2088,  2.071)  /* Senescence */
+     , (30683,  2168,  2.071)  /* Gelidite's Gift */
+     , (30683,  2170,  2.071)  /* Inferno's Gift */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30683,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30683, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,  0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30683,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30683, 9,  3693,  0, 0, 0.3, False) /* Create Banderling Scalp (3693) for ContainTreasure */
+     , (30683, 9,     0,  0, 0, 0.7, False) /* Create nothing for ContainTreasure */
+     , (30683, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30683, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30683, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30683, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */
+     , (30683, 9,  7825,  0, 0, 0.1, False) /* Create Brown Beans (7825) for ContainTreasure */
+     , (30683, 9,     0,  0, 0, 0.9, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30685 Withered Banderling Paragon - banderlingaggressorwithered - Level 161.sql
+++ b/Content/sql/weenies/30685 Withered Banderling Paragon - banderlingaggressorwithered - Level 161.sql
@@ -1,0 +1,182 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30685;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30685, 'banderlingaggressorwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30685,   1,         16) /* ItemType - Creature */
+     , (30685,   2,          2) /* CreatureType - Banderling */
+     , (30685,   3,         16) /* PaletteTemplate - Rose */
+     , (30685,   6,         -1) /* ItemsCapacity */
+     , (30685,   7,         -1) /* ContainersCapacity */
+     , (30685,  16,          1) /* ItemUseable - No */
+     , (30685,  25,        161) /* Level */
+     , (30685,  27,          0) /* ArmorType - None */
+     , (30685,  40,          2) /* CombatMode - Melee */
+     , (30685,  68,          3) /* TargetingTactic - Random, Focused */
+     , (30685,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30685, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (30685, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (30685, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30685, 146,     317860) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30685,   1, True ) /* Stuck */
+     , (30685,  11, False) /* IgnoreCollisions */
+     , (30685,  12, True ) /* ReportCollisions */
+     , (30685,  13, False) /* Ethereal */
+     , (30685, 103, True ) /* NonProjectileMagicImmune */
+     , (30685, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30685,   1,       5) /* HeartbeatInterval */
+     , (30685,   2,       0) /* HeartbeatTimestamp */
+     , (30685,   3,      16) /* HealthRate */
+     , (30685,   4,      25) /* StaminaRate */
+     , (30685,   5,       2) /* ManaRate */
+     , (30685,  12,     0.5) /* Shade */
+     , (30685,  13,    0.75) /* ArmorModVsSlash */
+     , (30685,  14,    0.75) /* ArmorModVsPierce */
+     , (30685,  15,    0.75) /* ArmorModVsBludgeon */
+     , (30685,  16,    0.75) /* ArmorModVsCold */
+     , (30685,  17,    0.85) /* ArmorModVsFire */
+     , (30685,  18,    0.55) /* ArmorModVsAcid */
+     , (30685,  19,    1.25) /* ArmorModVsElectric */
+     , (30685,  31,      22) /* VisualAwarenessRange */
+     , (30685,  34,       1) /* PowerupTime */
+     , (30685,  36,       1) /* ChargeSpeed */
+     , (30685,  39,     1.5) /* DefaultScale */
+     , (30685,  64,    0.55) /* ResistSlash */
+     , (30685,  65,    0.55) /* ResistPierce */
+     , (30685,  66,    0.55) /* ResistBludgeon */
+     , (30685,  67,    0.85) /* ResistFire */
+     , (30685,  68,    0.55) /* ResistCold */
+     , (30685,  69,    0.35) /* ResistAcid */
+     , (30685,  70,     2.1) /* ResistElectric */
+     , (30685,  71,       1) /* ResistHealthBoost */
+     , (30685,  72,       1) /* ResistStaminaDrain */
+     , (30685,  73,       1) /* ResistStaminaBoost */
+     , (30685,  74,       1) /* ResistManaDrain */
+     , (30685,  75,       1) /* ResistManaBoost */
+     , (30685, 104,      10) /* ObviousRadarRange */
+     , (30685, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30685,   1, 'Withered Banderling Paragon') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30685,   1, 0x020012B4) /* Setup */
+     , (30685,   2, 0x09000007) /* MotionTable */
+     , (30685,   3, 0x20000005) /* SoundTable */
+     , (30685,   4, 0x30000002) /* CombatTable */
+     , (30685,   6, 0x04001425) /* PaletteBase */
+     , (30685,   7, 0x100005A2) /* ClothingBase */
+     , (30685,   8, 0x0600103D) /* Icon */
+     , (30685,  22, 0x34000017) /* PhysicsEffectTable */
+     , (30685,  32,        423) /* WieldedTreasureType */
+     , (30685,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30685,   1, 340, 0, 0) /* Strength */
+     , (30685,   2, 340, 0, 0) /* Endurance */
+     , (30685,   3, 380, 0, 0) /* Quickness */
+     , (30685,   4, 340, 0, 0) /* Coordination */
+     , (30685,   5, 300, 0, 0) /* Focus */
+     , (30685,   6, 300, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30685,   1,  9830, 0, 0, 10000) /* MaxHealth */
+     , (30685,   3,  5660, 0, 0, 6000) /* MaxStamina */
+     , (30685,   5,     0, 0, 0, 300) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30685,  2, 0, 3, 0, 270, 0, 0) /* Bow                 Specialized */
+     , (30685,  4, 0, 3, 0, 272, 0, 0) /* Dagger              Specialized */
+     , (30685,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
+     , (30685,  7, 0, 3, 0, 436, 0, 0) /* MissileDefense      Specialized */
+     , (30685, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
+     , (30685, 15, 0, 3, 0, 360, 0, 0) /* MagicDefense        Specialized */
+     , (30685, 20, 0, 3, 0, 140, 0, 0) /* Deception           Specialized */
+     , (30685, 22, 0, 3, 0, 100, 0, 0) /* Jump                Specialized */
+     , (30685, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30685,  0,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30685,  1,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30685,  2,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30685,  3,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30685,  4,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30685,  5,  4, 120, 0.75,  750,  563,  563,  563,  563,  638,  413,  938,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30685,  6,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30685,  7,  4,  0,    0,  750,  563,  563,  563,  563,  638,  413,  938,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30685,  8,  4, 140, 0.75,  750,  563,  563,  563,  563,  638,  413,  938,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30685,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30685, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,  0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30685,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30685, 9,  3693,  0, 0, 0.05, False) /* Create Banderling Scalp (3693) for ContainTreasure */
+     , (30685, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */
+     , (30685, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30685, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30685, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30685, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */
+     , (30685, 9,  7825,  0, 0, 0.1, False) /* Create Brown Beans (7825) for ContainTreasure */
+     , (30685, 9,     0,  0, 0, 0.9, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30686 Withered Transcendent Tumerok - tumerokwarmongerwithered - Level 161.sql
+++ b/Content/sql/weenies/30686 Withered Transcendent Tumerok - tumerokwarmongerwithered - Level 161.sql
@@ -1,0 +1,142 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30686;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30686, 'tumerokwarmongerwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30686,   1,         16) /* ItemType - Creature */
+     , (30686,   2,          6) /* CreatureType - Tumerok */
+     , (30686,   3,          9) /* PaletteTemplate - Grey */
+     , (30686,   6,         -1) /* ItemsCapacity */
+     , (30686,   7,         -1) /* ContainersCapacity */
+     , (30686,  16,          1) /* ItemUseable - No */
+     , (30686,  25,        161) /* Level */
+     , (30686,  27,          0) /* ArmorType - None */
+     , (30686,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (30686,  72,          6) /* FriendType - Tumerok */
+     , (30686,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30686, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (30686, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (30686, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30686, 146,     294349) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30686,   1, True ) /* Stuck */
+     , (30686,   6, False) /* AiUsesMana */
+     , (30686,  11, False) /* IgnoreCollisions */
+     , (30686,  12, True ) /* ReportCollisions */
+     , (30686,  13, False) /* Ethereal */
+     , (30686,  50, True ) /* NeverFailCasting */
+     , (30686, 103, True ) /* NonProjectileMagicImmune */
+     , (30686, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30686,   1,       5) /* HeartbeatInterval */
+     , (30686,   2,       0) /* HeartbeatTimestamp */
+     , (30686,   3,     9.6) /* HealthRate */
+     , (30686,   4,      23) /* StaminaRate */
+     , (30686,   5,       8) /* ManaRate */
+     , (30686,  12,     0.5) /* Shade */
+     , (30686,  13,       1) /* ArmorModVsSlash */
+     , (30686,  14,       1) /* ArmorModVsPierce */
+     , (30686,  15,       1) /* ArmorModVsBludgeon */
+     , (30686,  16,       1) /* ArmorModVsCold */
+     , (30686,  17,       1) /* ArmorModVsFire */
+     , (30686,  18,       1) /* ArmorModVsAcid */
+     , (30686,  19,       1) /* ArmorModVsElectric */
+     , (30686,  31,      16) /* VisualAwarenessRange */
+     , (30686,  34,       1) /* PowerupTime */
+     , (30686,  36,       1) /* ChargeSpeed */
+     , (30686,  39,     1.3) /* DefaultScale */
+     , (30686,  64,       2) /* ResistSlash */
+     , (30686,  65,       1) /* ResistPierce */
+     , (30686,  66,       1) /* ResistBludgeon */
+     , (30686,  67,       1) /* ResistFire */
+     , (30686,  68,       1) /* ResistCold */
+     , (30686,  69,       1) /* ResistAcid */
+     , (30686,  70,       1) /* ResistElectric */
+     , (30686,  71,       1) /* ResistHealthBoost */
+     , (30686,  72,       1) /* ResistStaminaDrain */
+     , (30686,  73,       1) /* ResistStaminaBoost */
+     , (30686,  74,       1) /* ResistManaDrain */
+     , (30686,  75,       1) /* ResistManaBoost */
+     , (30686,  80,       3) /* AiUseMagicDelay */
+     , (30686, 104,      10) /* ObviousRadarRange */
+     , (30686, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30686,   1, 'Withered Transcendent Tumerok') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30686,   1, 0x020012B1) /* Setup */
+     , (30686,   2, 0x0900000A) /* MotionTable */
+     , (30686,   3, 0x20000013) /* SoundTable */
+     , (30686,   4, 0x3000000C) /* CombatTable */
+     , (30686,   6, 0x040001C2) /* PaletteBase */
+     , (30686,   7, 0x100005A3) /* ClothingBase */
+     , (30686,   8, 0x0600103C) /* Icon */
+     , (30686,  22, 0x34000026) /* PhysicsEffectTable */
+     , (30686,  32,        490) /* WieldedTreasureType */
+     , (30686,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30686,   1, 290, 0, 0) /* Strength */
+     , (30686,   2, 300, 0, 0) /* Endurance */
+     , (30686,   3, 325, 0, 0) /* Quickness */
+     , (30686,   4, 340, 0, 0) /* Coordination */
+     , (30686,   5, 280, 0, 0) /* Focus */
+     , (30686,   6, 270, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30686,   1,  4850, 0, 0, 5000) /* MaxHealth */
+     , (30686,   3,  4700, 0, 0, 5000) /* MaxStamina */
+     , (30686,   5,  4650, 0, 0, 4920) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30686,  2, 0, 3, 0, 250, 0, 0) /* Bow                 Specialized */
+     , (30686,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
+     , (30686,  7, 0, 3, 0, 430, 0, 0) /* MissileDefense      Specialized */
+     , (30686,  9, 0, 3, 0, 285, 0, 0) /* Spear               Specialized */
+     , (30686, 14, 0, 3, 0, 300, 0, 0) /* ArcaneLore          Specialized */
+     , (30686, 15, 0, 3, 0, 310, 0, 0) /* MagicDefense        Specialized */
+     , (30686, 20, 0, 3, 0, 150, 0, 0) /* Deception           Specialized */
+     , (30686, 24, 0, 3, 0, 160, 0, 0) /* Run                 Specialized */
+     , (30686, 31, 0, 3, 0, 230, 0, 0) /* CreatureEnchantment Specialized */
+     , (30686, 33, 0, 3, 0, 230, 0, 0) /* LifeMagic           Specialized */
+     , (30686, 34, 0, 3, 0, 230, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30686,  0,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30686,  1,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30686,  2,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30686,  3,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30686,  4,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30686,  5,  4, 50, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30686,  6,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30686,  7,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30686,  8,  4, 55, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (30686,    62,  2.015)  /* Acid Stream V */
+     , (30686,    68,  2.015)  /* Shock Wave V */
+     , (30686,    73,  2.015)  /* Frost Bolt V */
+     , (30686,    79,  2.015)  /* Lightning Bolt V */
+     , (30686,    84,  2.015)  /* Flame Bolt V */
+     , (30686,    90,  2.015)  /* Force Bolt V */
+     , (30686,    96,  2.015)  /* Whirling Blade V */
+     , (30686,  1160,  2.009)  /* Heal Self V */
+     , (30686,  1241,  2.012)  /* Drain Health Other V */
+     , (30686,  1342,  2.012)  /* Weakness Other V */
+     , (30686,  1395,  2.012)  /* Clumsiness Other V */
+     , (30686,  1419,  2.012)  /* Slowness Other V */
+     , (30686,  1443,  2.012)  /* Bafflement Other V */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30686,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30686, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30686, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30686, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30686, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30686, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30687 Withered Revered Tumerok Shaman - tumerokreveredshamanwithered - Level 161.sql
+++ b/Content/sql/weenies/30687 Withered Revered Tumerok Shaman - tumerokreveredshamanwithered - Level 161.sql
@@ -1,0 +1,149 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30687;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30687, 'tumerokreveredshamanwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30687,   1,         16) /* ItemType - Creature */
+     , (30687,   2,          6) /* CreatureType - Tumerok */
+     , (30687,   3,         39) /* PaletteTemplate - Black */
+     , (30687,   6,         -1) /* ItemsCapacity */
+     , (30687,   7,         -1) /* ContainersCapacity */
+     , (30687,  16,          1) /* ItemUseable - No */
+     , (30687,  25,        161) /* Level */
+     , (30687,  27,          0) /* ArmorType - None */
+     , (30687,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (30687,  72,          6) /* FriendType - Tumerok */
+     , (30687,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30687, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (30687, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (30687, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30687, 146,     243771) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30687,   1, True ) /* Stuck */
+     , (30687,   6, True ) /* AiUsesMana */
+     , (30687,  11, False) /* IgnoreCollisions */
+     , (30687,  12, True ) /* ReportCollisions */
+     , (30687,  13, False) /* Ethereal */
+     , (30687,  50, True ) /* NeverFailCasting */
+     , (30687, 103, True ) /* NonProjectileMagicImmune */
+     , (30687, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30687,   1,       5) /* HeartbeatInterval */
+     , (30687,   2,       0) /* HeartbeatTimestamp */
+     , (30687,   3,       6) /* HealthRate */
+     , (30687,   4,      10) /* StaminaRate */
+     , (30687,   5,       5) /* ManaRate */
+     , (30687,  12,     0.5) /* Shade */
+     , (30687,  13,       1) /* ArmorModVsSlash */
+     , (30687,  14,       1) /* ArmorModVsPierce */
+     , (30687,  15,       1) /* ArmorModVsBludgeon */
+     , (30687,  16,       1) /* ArmorModVsCold */
+     , (30687,  17,       1) /* ArmorModVsFire */
+     , (30687,  18,       1) /* ArmorModVsAcid */
+     , (30687,  19,       1) /* ArmorModVsElectric */
+     , (30687,  31,      16) /* VisualAwarenessRange */
+     , (30687,  34,       1) /* PowerupTime */
+     , (30687,  36,       1) /* ChargeSpeed */
+     , (30687,  39,     1.3) /* DefaultScale */
+     , (30687,  64,       2) /* ResistSlash */
+     , (30687,  65,       1) /* ResistPierce */
+     , (30687,  66,       1) /* ResistBludgeon */
+     , (30687,  67,       1) /* ResistFire */
+     , (30687,  68,       1) /* ResistCold */
+     , (30687,  69,       1) /* ResistAcid */
+     , (30687,  70,       1) /* ResistElectric */
+     , (30687,  71,       1) /* ResistHealthBoost */
+     , (30687,  72,       1) /* ResistStaminaDrain */
+     , (30687,  73,       1) /* ResistStaminaBoost */
+     , (30687,  74,       1) /* ResistManaDrain */
+     , (30687,  75,       1) /* ResistManaBoost */
+     , (30687,  80,       3) /* AiUseMagicDelay */
+     , (30687, 104,      10) /* ObviousRadarRange */
+     , (30687, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30687,   1, 'Withered Revered Tumerok Shaman') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30687,   1, 0x020012B1) /* Setup */
+     , (30687,   2, 0x0900000A) /* MotionTable */
+     , (30687,   3, 0x20000013) /* SoundTable */
+     , (30687,   4, 0x3000000C) /* CombatTable */
+     , (30687,   6, 0x040001C2) /* PaletteBase */
+     , (30687,   7, 0x100005A3) /* ClothingBase */
+     , (30687,   8, 0x0600103C) /* Icon */
+     , (30687,  22, 0x34000026) /* PhysicsEffectTable */
+     , (30687,  32,        490) /* WieldedTreasureType */
+     , (30687,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30687,   1, 260, 0, 0) /* Strength */
+     , (30687,   2, 300, 0, 0) /* Endurance */
+     , (30687,   3, 325, 0, 0) /* Quickness */
+     , (30687,   4, 300, 0, 0) /* Coordination */
+     , (30687,   5, 320, 0, 0) /* Focus */
+     , (30687,   6, 350, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30687,   1,  4850, 0, 0, 5000) /* MaxHealth */
+     , (30687,   3,  4700, 0, 0, 5000) /* MaxStamina */
+     , (30687,   5,  4650, 0, 0, 5000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30687,  2, 0, 3, 0, 240, 0, 0) /* Bow                 Specialized */
+     , (30687,  4, 0, 3, 0, 285, 0, 0) /* Dagger              Specialized */
+     , (30687,  6, 0, 3, 0, 320, 0, 0) /* MeleeDefense        Specialized */
+     , (30687,  7, 0, 3, 0, 430, 0, 0) /* MissileDefense      Specialized */
+     , (30687, 14, 0, 3, 0, 300, 0, 0) /* ArcaneLore          Specialized */
+     , (30687, 15, 0, 3, 0, 295, 0, 0) /* MagicDefense        Specialized */
+     , (30687, 20, 0, 3, 0, 150, 0, 0) /* Deception           Specialized */
+     , (30687, 24, 0, 3, 0,  60, 0, 0) /* Run                 Specialized */
+     , (30687, 31, 0, 3, 0, 230, 0, 0) /* CreatureEnchantment Specialized */
+     , (30687, 33, 0, 3, 0, 230, 0, 0) /* LifeMagic           Specialized */
+     , (30687, 34, 0, 3, 0, 230, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30687,  0,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30687,  1,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30687,  2,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30687,  3,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30687,  4,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30687,  5,  4, 50, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30687,  6,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30687,  7,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30687,  8,  4, 55, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (30687,    63,  2.015)  /* Acid Stream VI */
+     , (30687,    69,  2.015)  /* Shock Wave VI */
+     , (30687,    74,  2.015)  /* Frost Bolt VI */
+     , (30687,    80,  2.015)  /* Lightning Bolt VI */
+     , (30687,    85,  2.015)  /* Flame Bolt VI */
+     , (30687,    91,  2.015)  /* Force Bolt VI */
+     , (30687,    97,  2.015)  /* Whirling Blade VI */
+     , (30687,   106,  2.015)  /* Shock Blast VI */
+     , (30687,   138,  2.015)  /* Frost Volley VI */
+     , (30687,   142,  2.015)  /* Lightning Volley VI */
+     , (30687,   146,  2.015)  /* Flame Volley VI */
+     , (30687,   154,  2.015)  /* Blade Volley VI */
+     , (30687,   234,  2.012)  /* Vulnerability Other VI */
+     , (30687,   267,  2.012)  /* Defenselessness Other VI */
+     , (30687,   285,  2.012)  /* Magic Yield Other VI */
+     , (30687,  1161,  2.009)  /* Heal Self VI */
+     , (30687,  1176,  2.012)  /* Harm Other VI */
+     , (30687,  1200,  2.012)  /* Enfeeble Other VI */
+     , (30687,  1265,  2.012)  /* Drain Mana Other VI */
+     , (30687,  1468,  2.012)  /* Feeblemind Other VI */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30687,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30687, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30687, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30687, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30687, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30687, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30689 Withered Raider Prefect - lugiantitanwithered - Level 161.sql
+++ b/Content/sql/weenies/30689 Withered Raider Prefect - lugiantitanwithered - Level 161.sql
@@ -1,0 +1,178 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30689;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30689, 'lugiantitanwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30689,   1,         16) /* ItemType - Creature */
+     , (30689,   2,         70) /* CreatureType - GotrokLugian */
+     , (30689,   3,         17) /* PaletteTemplate - Yellow */
+     , (30689,   6,         -1) /* ItemsCapacity */
+     , (30689,   7,         -1) /* ContainersCapacity */
+     , (30689,   8,       8000) /* Mass */
+     , (30689,  16,          1) /* ItemUseable - No */
+     , (30689,  25,        161) /* Level */
+     , (30689,  27,          0) /* ArmorType - None */
+     , (30689,  40,          2) /* CombatMode - Melee */
+     , (30689,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (30689,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30689, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (30689, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (30689, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30689, 146,     306724) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30689,   1, True ) /* Stuck */
+     , (30689,  11, False) /* IgnoreCollisions */
+     , (30689,  12, True ) /* ReportCollisions */
+     , (30689,  13, False) /* Ethereal */
+     , (30689, 103, True ) /* NonProjectileMagicImmune */
+     , (30689, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30689,   1,       5) /* HeartbeatInterval */
+     , (30689,   2,       0) /* HeartbeatTimestamp */
+     , (30689,   3,       8) /* HealthRate */
+     , (30689,   4,      20) /* StaminaRate */
+     , (30689,   5,       2) /* ManaRate */
+     , (30689,  12,     0.5) /* Shade */
+     , (30689,  13,     0.6) /* ArmorModVsSlash */
+     , (30689,  14,     0.6) /* ArmorModVsPierce */
+     , (30689,  15,     0.6) /* ArmorModVsBludgeon */
+     , (30689,  16,    0.35) /* ArmorModVsCold */
+     , (30689,  17,    0.25) /* ArmorModVsFire */
+     , (30689,  18,    0.85) /* ArmorModVsAcid */
+     , (30689,  19,     0.8) /* ArmorModVsElectric */
+     , (30689,  31,      23) /* VisualAwarenessRange */
+     , (30689,  34,       3) /* PowerupTime */
+     , (30689,  36,       1) /* ChargeSpeed */
+     , (30689,  64,    0.65) /* ResistSlash */
+     , (30689,  65,    0.65) /* ResistPierce */
+     , (30689,  66,    0.65) /* ResistBludgeon */
+     , (30689,  67,    0.25) /* ResistFire */
+     , (30689,  68,     0.4) /* ResistCold */
+     , (30689,  69,     0.9) /* ResistAcid */
+     , (30689,  70,       2) /* ResistElectric */
+     , (30689,  71,       1) /* ResistHealthBoost */
+     , (30689,  72,       1) /* ResistStaminaDrain */
+     , (30689,  73,       1) /* ResistStaminaBoost */
+     , (30689,  74,       1) /* ResistManaDrain */
+     , (30689,  75,       1) /* ResistManaBoost */
+     , (30689, 104,      10) /* ObviousRadarRange */
+     , (30689, 117,     0.5) /* FocusedProbability */
+     , (30689, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30689,   1, 'Withered Raider Prefect') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30689,   1, 0x020012B3) /* Setup */
+     , (30689,   2, 0x09000006) /* MotionTable */
+     , (30689,   3, 0x2000000A) /* SoundTable */
+     , (30689,   4, 0x30000003) /* CombatTable */
+     , (30689,   6, 0x040010C6) /* PaletteBase */
+     , (30689,   7, 0x1000059F) /* ClothingBase */
+     , (30689,   8, 0x06001037) /* Icon */
+     , (30689,  22, 0x3400001E) /* PhysicsEffectTable */
+     , (30689,  32,        425) /* WieldedTreasureType */
+     , (30689,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30689,   1, 280, 0, 0) /* Strength */
+     , (30689,   2, 340, 0, 0) /* Endurance */
+     , (30689,   3, 290, 0, 0) /* Quickness */
+     , (30689,   4, 290, 0, 0) /* Coordination */
+     , (30689,   5, 180, 0, 0) /* Focus */
+     , (30689,   6, 240, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30689,   1,  9830, 0, 0, 10000) /* MaxHealth */
+     , (30689,   3,  5660, 0, 0, 6000) /* MaxStamina */
+     , (30689,   5,     0, 0, 0, 240) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30689,  2, 0, 3, 0, 290, 0, 0) /* Bow                 Specialized */
+     , (30689,  4, 0, 3, 0, 293, 0, 0) /* Dagger              Specialized */
+     , (30689,  6, 0, 3, 0, 312, 0, 0) /* MeleeDefense        Specialized */
+     , (30689,  7, 0, 3, 0, 463, 0, 0) /* MissileDefense      Specialized */
+     , (30689, 15, 0, 3, 0, 355, 0, 0) /* MagicDefense        Specialized */
+     , (30689, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
+     , (30689, 22, 0, 3, 0,  80, 0, 0) /* Jump                Specialized */
+     , (30689, 24, 0, 3, 0,  75, 0, 0) /* Run                 Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30689,  0,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30689,  1,  4, 40,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30689,  2,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30689,  3,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30689,  4,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30689,  5,  4, 200, 0.75,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30689,  6,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30689,  7,  4, 25,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30689,  8,  4, 200, 0.75,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30689,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30689, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,  0.125, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,  0.025, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30689,  5 /* HeartBeat */,  0.125, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30689, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30689, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30689, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30689, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/30691 Withered Raider Justicar - lugianjuggernautwithered - Level 161.sql
+++ b/Content/sql/weenies/30691 Withered Raider Justicar - lugianjuggernautwithered - Level 161.sql
@@ -1,0 +1,194 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30691;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30691, 'lugianjuggernautwithered', 10, '2019-09-13 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30691,   1,         16) /* ItemType - Creature */
+     , (30691,   2,         70) /* CreatureType - GotrokLugian */
+     , (30691,   3,          8) /* PaletteTemplate - Green */
+     , (30691,   6,         -1) /* ItemsCapacity */
+     , (30691,   7,         -1) /* ContainersCapacity */
+     , (30691,   8,       8000) /* Mass */
+     , (30691,  16,          1) /* ItemUseable - No */
+     , (30691,  25,        161) /* Level */
+     , (30691,  27,          0) /* ArmorType - None */
+     , (30691,  40,          2) /* CombatMode - Melee */
+     , (30691,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (30691,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (30691, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (30691, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (30691, 140,          1) /* AiOptions - CanOpenDoors */
+     , (30691, 146,     302931) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30691,    1, True ) /* Stuck */
+     , (30691,   11, False) /* IgnoreCollisions */
+     , (30691,   12, True ) /* ReportCollisions */
+     , (30691,   13, False) /* Ethereal */
+     , (30691,  103, True ) /* NonProjectileMagicImmune */
+     , (30691, 9016, True) /* UseXpOverride */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30691,   1,       5) /* HeartbeatInterval */
+     , (30691,   2,       0) /* HeartbeatTimestamp */
+     , (30691,   3,     0.9) /* HealthRate */
+     , (30691,   4,       4) /* StaminaRate */
+     , (30691,   5,       2) /* ManaRate */
+     , (30691,  12,     0.5) /* Shade */
+     , (30691,  13,     0.6) /* ArmorModVsSlash */
+     , (30691,  14,     0.6) /* ArmorModVsPierce */
+     , (30691,  15,     0.6) /* ArmorModVsBludgeon */
+     , (30691,  16,    0.35) /* ArmorModVsCold */
+     , (30691,  17,    0.25) /* ArmorModVsFire */
+     , (30691,  18,    0.85) /* ArmorModVsAcid */
+     , (30691,  19,     0.8) /* ArmorModVsElectric */
+     , (30691,  31,      23) /* VisualAwarenessRange */
+     , (30691,  34,       3) /* PowerupTime */
+     , (30691,  36,       1) /* ChargeSpeed */
+     , (30691,  64,    0.65) /* ResistSlash */
+     , (30691,  65,    0.65) /* ResistPierce */
+     , (30691,  66,    0.65) /* ResistBludgeon */
+     , (30691,  67,    0.25) /* ResistFire */
+     , (30691,  68,     0.4) /* ResistCold */
+     , (30691,  69,     0.9) /* ResistAcid */
+     , (30691,  70,       2) /* ResistElectric */
+     , (30691,  71,       1) /* ResistHealthBoost */
+     , (30691,  72,       1) /* ResistStaminaDrain */
+     , (30691,  73,       1) /* ResistStaminaBoost */
+     , (30691,  74,       1) /* ResistManaDrain */
+     , (30691,  75,       1) /* ResistManaBoost */
+     , (30691, 104,      10) /* ObviousRadarRange */
+     , (30691, 117,     0.5) /* FocusedProbability */
+     , (30691, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30691,   1, 'Withered Raider Justicar') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30691,   1, 0x020012B3) /* Setup */
+     , (30691,   2, 0x09000006) /* MotionTable */
+     , (30691,   3, 0x2000000A) /* SoundTable */
+     , (30691,   4, 0x30000003) /* CombatTable */
+     , (30691,   6, 0x040010C6) /* PaletteBase */
+     , (30691,   7, 0x1000059F) /* ClothingBase */
+     , (30691,   8, 0x06001037) /* Icon */
+     , (30691,  22, 0x3400001E) /* PhysicsEffectTable */
+     , (30691,  32,        424) /* WieldedTreasureType */
+     , (30691,  35,        449) /* DeathTreasureType - T6_General - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (30691,   1, 340, 0, 0) /* Strength */
+     , (30691,   2, 340, 0, 0) /* Endurance */
+     , (30691,   3, 220, 0, 0) /* Quickness */
+     , (30691,   4, 290, 0, 0) /* Coordination */
+     , (30691,   5, 180, 0, 0) /* Focus */
+     , (30691,   6, 240, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (30691,   1,  9830, 0, 0, 10000) /* MaxHealth */
+     , (30691,   3,  5660, 0, 0, 6000) /* MaxStamina */
+     , (30691,   5,     0, 0, 0, 240) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (30691,  1, 0, 3, 0, 283, 0, 0) /* Axe                 Specialized */
+     , (30691,  6, 0, 3, 0, 335, 0, 0) /* MeleeDefense        Specialized */
+     , (30691,  7, 0, 3, 0, 463, 0, 0) /* MissileDefense      Specialized */
+     , (30691, 12, 0, 3, 0, 260, 0, 0) /* ThrownWeapon        Specialized */
+     , (30691, 15, 0, 3, 0, 355, 0, 0) /* MagicDefense        Specialized */
+     , (30691, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
+     , (30691, 22, 0, 3, 0,  80, 0, 0) /* Jump                Specialized */
+     , (30691, 24, 0, 3, 0,  45, 0, 0) /* Run                 Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (30691,  0,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (30691,  1,  4, 40,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (30691,  2,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (30691,  3,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (30691,  4,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (30691,  5,  4, 200, 0.75,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (30691,  6,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (30691,  7,  4, 25,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (30691,  8,  4, 200, 0.75,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (30691,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (30691, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,  0.125, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,  0.025, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691,  5 /* HeartBeat */,  0.125, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691, 16 /* KillTaunt */,  0.001, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Eat fiery hot justice, evil doer!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (30691, 21 /* ResistSpell */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Cruath Quafeth.  Your kind says that often when hunting us.  Does it mean kill me now?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (30691, 9, 23108,  0, 0, 0.02, False) /* Create Twisted Dark Key (23108) for ContainTreasure */
+     , (30691, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (30691, 9, 23107,  0, 0, 0.01, False) /* Create Mangled Dark Key (23107) for ContainTreasure */
+     , (30691, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Content/sql/weenies/42403 Leather Vest.sql
+++ b/Content/sql/weenies/42403 Leather Vest.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42403;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42403, 'ace42403-leathervest', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42403,   1,       2048) /* ItemType - Gem */
+     , (42403,   4,      32768) /* ClothingPriority - Hands */
+     , (42403,   5,        919) /* EncumbranceVal */
+     , (42403,  11,          1) /* MaxStackSize */
+     , (42403,  12,          1) /* StackSize */
+     , (42403,  13,        919) /* StackUnitEncumbrance */
+     , (42403,  15,        653) /* StackUnitValue */
+     , (42403,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42403,  19,        653) /* Value */
+     , (42403,  28,          0) /* ArmorLevel */
+     , (42403,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42403,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42403,  22, True ) /* Inscribable */
+     , (42403, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42403,  13,     1.3) /* ArmorModVsSlash */
+     , (42403,  14,       1) /* ArmorModVsPierce */
+     , (42403,  15,       1) /* ArmorModVsBludgeon */
+     , (42403,  16,     0.4) /* ArmorModVsCold */
+     , (42403,  17,     0.4) /* ArmorModVsFire */
+     , (42403,  18,     0.6) /* ArmorModVsAcid */
+     , (42403,  19,     0.4) /* ArmorModVsElectric */
+     , (42403, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42403,   1, 'Leather Vest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42403,   1, 0x020000D2) /* Setup */
+     , (42403,   3, 0x20000014) /* SoundTable */
+     , (42403,   6, 0x0400007E) /* PaletteBase */
+     , (42403,   8, 0x06002E1F) /* Icon */
+     , (42403,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42403,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42405 Dusky Winged Coat.sql
+++ b/Content/sql/weenies/42405 Dusky Winged Coat.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42405;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42405, 'ace42405-duskywingedcoat', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42405,   1,       2048) /* ItemType - Gem */
+     , (42405,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (42405,   5,        919) /* EncumbranceVal */
+     , (42405,  11,          1) /* MaxStackSize */
+     , (42405,  12,          1) /* StackSize */
+     , (42405,  13,        919) /* StackUnitEncumbrance */
+     , (42405,  15,        653) /* StackUnitValue */
+     , (42405,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42405,  19,        653) /* Value */
+     , (42405,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42405,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42405,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42405,   1, 'Dusky Winged Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42405,   1, 0x020001A6) /* Setup */
+     , (42405,   3, 0x20000014) /* SoundTable */
+     , (42405,   6, 0x0400007E) /* PaletteBase */
+     , (42405,   8, 0x060034E1) /* Icon */
+     , (42405,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42405,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42407 Platemail Gauntlets.sql
+++ b/Content/sql/weenies/42407 Platemail Gauntlets.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42407;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42407, 'ace42407-platemailgauntlets', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42407,   1,       2048) /* ItemType - Gem */
+     , (42407,   4,      32768) /* ClothingPriority - Hands */
+     , (42407,   5,        919) /* EncumbranceVal */
+     , (42407,  11,          1) /* MaxStackSize */
+     , (42407,  12,          1) /* StackSize */
+     , (42407,  13,        919) /* StackUnitEncumbrance */
+     , (42407,  15,        653) /* StackUnitValue */
+     , (42407,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42407,  19,        653) /* Value */
+     , (42407,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42407,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42407,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42407,   1, 'Platemail Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42407,   1, 0x020000D8) /* Setup */
+     , (42407,   3, 0x20000014) /* SoundTable */
+     , (42407,   6, 0x0400007E) /* PaletteBase */
+     , (42407,   8, 0x06000FCD) /* Icon */
+     , (42407,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42407,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42409 Yoroi Girth.sql
+++ b/Content/sql/weenies/42409 Yoroi Girth.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42409;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42409, 'ace42409-yoroigirth', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42409,   1,       2048) /* ItemType - Gem */
+     , (42409,   4,      32768) /* ClothingPriority - Hands */
+     , (42409,   5,        919) /* EncumbranceVal */
+     , (42409,  11,          1) /* MaxStackSize */
+     , (42409,  12,          1) /* StackSize */
+     , (42409,  13,        919) /* StackUnitEncumbrance */
+     , (42409,  15,        653) /* StackUnitValue */
+     , (42409,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42409,  19,        653) /* Value */
+     , (42409,  28,          0) /* ArmorLevel */
+     , (42409,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42409,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42409,  22, True ) /* Inscribable */
+     , (42409, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42409,  13,     1.3) /* ArmorModVsSlash */
+     , (42409,  14,       1) /* ArmorModVsPierce */
+     , (42409,  15,       1) /* ArmorModVsBludgeon */
+     , (42409,  16,     0.4) /* ArmorModVsCold */
+     , (42409,  17,     0.4) /* ArmorModVsFire */
+     , (42409,  18,     0.6) /* ArmorModVsAcid */
+     , (42409,  19,     0.4) /* ArmorModVsElectric */
+     , (42409, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42409,   1, 'Yoroi Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42409,   1, 0x020000D7) /* Setup */
+     , (42409,   3, 0x20000014) /* SoundTable */
+     , (42409,   6, 0x0400007E) /* PaletteBase */
+     , (42409,   8, 0x060012F2) /* Icon */
+     , (42409,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42409,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42411 Yoroi Greaves.sql
+++ b/Content/sql/weenies/42411 Yoroi Greaves.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42411;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42411, 'ace42411-yoroigreaves', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42411,   1,       2048) /* ItemType - Gem */
+     , (42411,   4,      32768) /* ClothingPriority - Hands */
+     , (42411,   5,        919) /* EncumbranceVal */
+     , (42411,  11,          1) /* MaxStackSize */
+     , (42411,  12,          1) /* StackSize */
+     , (42411,  13,        919) /* StackUnitEncumbrance */
+     , (42411,  15,        653) /* StackUnitValue */
+     , (42411,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42411,  19,        653) /* Value */
+     , (42411,  28,          0) /* ArmorLevel */
+     , (42411,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42411,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42411,  22, True ) /* Inscribable */
+     , (42411, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42411,  13,     1.3) /* ArmorModVsSlash */
+     , (42411,  14,       1) /* ArmorModVsPierce */
+     , (42411,  15,       1) /* ArmorModVsBludgeon */
+     , (42411,  16,     0.4) /* ArmorModVsCold */
+     , (42411,  17,     0.4) /* ArmorModVsFire */
+     , (42411,  18,     0.6) /* ArmorModVsAcid */
+     , (42411,  19,     0.4) /* ArmorModVsElectric */
+     , (42411, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42411,   1, 'Yoroi Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42411,   1, 0x020000D1) /* Setup */
+     , (42411,   3, 0x20000014) /* SoundTable */
+     , (42411,   6, 0x0400007E) /* PaletteBase */
+     , (42411,   8, 0x06001308) /* Icon */
+     , (42411,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42411,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42414 Heaume.sql
+++ b/Content/sql/weenies/42414 Heaume.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42414;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42414, 'ace42414-heaume', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42414,   1,       2048) /* ItemType - Gem */
+     , (42414,   4,      32768) /* ClothingPriority - Hands */
+     , (42414,   5,        919) /* EncumbranceVal */
+     , (42414,  11,          1) /* MaxStackSize */
+     , (42414,  12,          1) /* StackSize */
+     , (42414,  13,        919) /* StackUnitEncumbrance */
+     , (42414,  15,        653) /* StackUnitValue */
+     , (42414,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42414,  19,        653) /* Value */
+     , (42414,  28,          0) /* ArmorLevel */
+     , (42414,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42414,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42414,  22, True ) /* Inscribable */
+     , (42414, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42414,  13,     1.3) /* ArmorModVsSlash */
+     , (42414,  14,       1) /* ArmorModVsPierce */
+     , (42414,  15,       1) /* ArmorModVsBludgeon */
+     , (42414,  16,     0.4) /* ArmorModVsCold */
+     , (42414,  17,     0.4) /* ArmorModVsFire */
+     , (42414,  18,     0.6) /* ArmorModVsAcid */
+     , (42414,  19,     0.4) /* ArmorModVsElectric */
+     , (42414, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42414,   1, 'Heaume') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42414,   1, 0x02000330) /* Setup */
+     , (42414,   3, 0x20000014) /* SoundTable */
+     , (42414,   6, 0x0400007E) /* PaletteBase */
+     , (42414,   8, 0x060017E3) /* Icon */
+     , (42414,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42414,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42416 Yoroi Leggings.sql
+++ b/Content/sql/weenies/42416 Yoroi Leggings.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42416;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42416, 'ace42416-yoroileggings', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42416,   1,       2048) /* ItemType - Gem */
+     , (42416,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (42416,   5,        919) /* EncumbranceVal */
+     , (42416,  11,          1) /* MaxStackSize */
+     , (42416,  12,          1) /* StackSize */
+     , (42416,  13,        919) /* StackUnitEncumbrance */
+     , (42416,  15,        653) /* StackUnitValue */
+     , (42416,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42416,  19,        653) /* Value */
+     , (42416,  28,          0) /* ArmorLevel */
+     , (42416,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42416,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42416,  22, True ) /* Inscribable */
+     , (42416, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42416,  13,     1.3) /* ArmorModVsSlash */
+     , (42416,  14,       1) /* ArmorModVsPierce */
+     , (42416,  15,       1) /* ArmorModVsBludgeon */
+     , (42416,  16,     0.4) /* ArmorModVsCold */
+     , (42416,  17,     0.4) /* ArmorModVsFire */
+     , (42416,  18,     0.6) /* ArmorModVsAcid */
+     , (42416,  19,     0.4) /* ArmorModVsElectric */
+     , (42416, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42416,   1, 'Yoroi Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42416,   1, 0x020001A8) /* Setup */
+     , (42416,   3, 0x20000014) /* SoundTable */
+     , (42416,   6, 0x0400007E) /* PaletteBase */
+     , (42416,   8, 0x06000FDC) /* Icon */
+     , (42416,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42416,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42417 Olthoi Amuli Leggings.sql
+++ b/Content/sql/weenies/42417 Olthoi Amuli Leggings.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42417;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42417, 'ace42417-olthoiamulileggings', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42417,   1,       2048) /* ItemType - Gem */
+     , (42417,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (42417,   5,        919) /* EncumbranceVal */
+     , (42417,  11,          1) /* MaxStackSize */
+     , (42417,  12,          1) /* StackSize */
+     , (42417,  13,        919) /* StackUnitEncumbrance */
+     , (42417,  15,        653) /* StackUnitValue */
+     , (42417,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42417,  19,        653) /* Value */
+     , (42417,  28,          0) /* ArmorLevel */
+     , (42417,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42417,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42417,  22, True ) /* Inscribable */
+     , (42417, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42417,  13,     1.3) /* ArmorModVsSlash */
+     , (42417,  14,       1) /* ArmorModVsPierce */
+     , (42417,  15,       1) /* ArmorModVsBludgeon */
+     , (42417,  16,     0.4) /* ArmorModVsCold */
+     , (42417,  17,     0.4) /* ArmorModVsFire */
+     , (42417,  18,     0.6) /* ArmorModVsAcid */
+     , (42417,  19,     0.4) /* ArmorModVsElectric */
+     , (42417, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42417,   1, 'Olthoi Amuli Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42417,   1, 0x020001A8) /* Setup */
+     , (42417,   3, 0x20000014) /* SoundTable */
+     , (42417,   6, 0x0400007E) /* PaletteBase */
+     , (42417,   8, 0x060068B0) /* Icon */
+     , (42417,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42417,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42418 Yoroi Pauldrons.sql
+++ b/Content/sql/weenies/42418 Yoroi Pauldrons.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42418;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42418, 'ace42418-yoroipauldrons', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42418,   1,       2048) /* ItemType - Gem */
+     , (42418,   4,      32768) /* ClothingPriority - Hands */
+     , (42418,   5,        919) /* EncumbranceVal */
+     , (42418,  11,          1) /* MaxStackSize */
+     , (42418,  12,          1) /* StackSize */
+     , (42418,  13,        919) /* StackUnitEncumbrance */
+     , (42418,  15,        653) /* StackUnitValue */
+     , (42418,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42418,  19,        653) /* Value */
+     , (42418,  28,          0) /* ArmorLevel */
+     , (42418,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42418,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42418,  22, True ) /* Inscribable */
+     , (42418, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42418,  13,     1.3) /* ArmorModVsSlash */
+     , (42418,  14,       1) /* ArmorModVsPierce */
+     , (42418,  15,       1) /* ArmorModVsBludgeon */
+     , (42418,  16,     0.4) /* ArmorModVsCold */
+     , (42418,  17,     0.4) /* ArmorModVsFire */
+     , (42418,  18,     0.6) /* ArmorModVsAcid */
+     , (42418,  19,     0.4) /* ArmorModVsElectric */
+     , (42418, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42418,   1, 'Yoroi Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42418,   1, 0x020000D1) /* Setup */
+     , (42418,   3, 0x20000014) /* SoundTable */
+     , (42418,   6, 0x0400007E) /* PaletteBase */
+     , (42418,   8, 0x0600130F) /* Icon */
+     , (42418,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42418,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42421 Celdon Sleeves.sql
+++ b/Content/sql/weenies/42421 Celdon Sleeves.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42421;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42421, 'ace42421-celdonsleeves', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42421,   1,       2048) /* ItemType - Gem */
+     , (42421,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (42421,   5,        919) /* EncumbranceVal */
+     , (42421,  11,          1) /* MaxStackSize */
+     , (42421,  12,          1) /* StackSize */
+     , (42421,  13,        919) /* StackUnitEncumbrance */
+     , (42421,  15,        653) /* StackUnitValue */
+     , (42421,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42421,  19,        653) /* Value */
+     , (42421,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42421,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42421,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42421,   1, 'Celdon Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42421,   1, 0x020000DF) /* Setup */
+     , (42421,   3, 0x20000014) /* SoundTable */
+     , (42421,   6, 0x0400007E) /* PaletteBase */
+     , (42421,   8, 0x06001BD8) /* Icon */
+     , (42421,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42421,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/42422 Leather Boots.sql
+++ b/Content/sql/weenies/42422 Leather Boots.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42422;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42422, 'ace42422-leatherboots', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42422,   1,       2048) /* ItemType - Gem */
+     , (42422,   4,      32768) /* ClothingPriority - Hands */
+     , (42422,   5,        919) /* EncumbranceVal */
+     , (42422,  11,          1) /* MaxStackSize */
+     , (42422,  12,          1) /* StackSize */
+     , (42422,  13,        919) /* StackUnitEncumbrance */
+     , (42422,  15,        653) /* StackUnitValue */
+     , (42422,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (42422,  19,        653) /* Value */
+     , (42422,  28,          0) /* ArmorLevel */
+     , (42422,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (42422,  94,          6) /* TargetType - Vestements */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42422,  22, True ) /* Inscribable */
+     , (42422, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42422,  13,     1.3) /* ArmorModVsSlash */
+     , (42422,  14,       1) /* ArmorModVsPierce */
+     , (42422,  15,       1) /* ArmorModVsBludgeon */
+     , (42422,  16,     0.4) /* ArmorModVsCold */
+     , (42422,  17,     0.4) /* ArmorModVsFire */
+     , (42422,  18,     0.6) /* ArmorModVsAcid */
+     , (42422,  19,     0.4) /* ArmorModVsElectric */
+     , (42422, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42422,   1, 'Leather Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42422,   1, 0x020008CB) /* Setup */
+     , (42422,   3, 0x20000014) /* SoundTable */
+     , (42422,   6, 0x0400007E) /* PaletteBase */
+     , (42422,   8, 0x06002DF4) /* Icon */
+     , (42422,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (42422,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/44863 Rynthid Energy Tentacles.sql
+++ b/Content/sql/weenies/44863 Rynthid Energy Tentacles.sql
@@ -1,0 +1,42 @@
+DELETE FROM `weenie` WHERE `class_Id` = 44863;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (44863, 'ace44863-rynthidenergytentacles', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (44863,   1,       2048) /* ItemType - Gem */
+     , (44863,   4,     131072) /* ClothingPriority - 131072 */
+     , (44863,   5,        919) /* EncumbranceVal */
+     , (44863,  11,          1) /* MaxStackSize */
+     , (44863,  12,          1) /* StackSize */
+     , (44863,  13,        919) /* StackUnitEncumbrance */
+     , (44863,  15,        653) /* StackUnitValue */
+     , (44863,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (44863,  19,        653) /* Value */
+     , (44863,  28,          0) /* ArmorLevel */
+     , (44863,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (44863,  94,          4) /* TargetType - Clothing */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (44863,  22, True ) /* Inscribable */
+     , (44863, 100, False) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (44863,  13,     0.8) /* ArmorModVsSlash */
+     , (44863,  14,     0.8) /* ArmorModVsPierce */
+     , (44863,  15,       1) /* ArmorModVsBludgeon */
+     , (44863,  16,     0.2) /* ArmorModVsCold */
+     , (44863,  17,     0.2) /* ArmorModVsFire */
+     , (44863,  18,     0.1) /* ArmorModVsAcid */
+     , (44863,  19,     0.2) /* ArmorModVsElectric */
+     , (44863, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (44863,   1, 'Rynthid Energy Tentacles') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (44863,   1, 0x02001B2A) /* Setup */
+     , (44863,   3, 0x20000014) /* SoundTable */
+     , (44863,   8, 0x060074E9) /* Icon */
+     , (44863,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (44863,  50, 0x060011F7) /* IconOverlay */;

--- a/Content/sql/weenies/50150 PK Trophy (Low).sql
+++ b/Content/sql/weenies/50150 PK Trophy (Low).sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 50150;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (50150, 'pktrophy_low', 35, '2023-05-13 16:20:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (50150,   1,      32768) /* ItemType - Caster */
+     , (50150,   3,         2) /* PaletteTemplate - Red */
+     , (50150,   5,         50) /* EncumbranceVal */
+     , (50150,   8,         50) /* Mass */
+     , (50150,   9,   16777216) /* ValidLocations - Held */
+     , (50150,  16,    6291464) /* ItemUseable - SourceContainedTargetRemoteNeverWalk */
+     , (50150,  18,          1) /* UiEffects - Magical */
+     , (50150,  19,        666) /* Value */
+     , (50150,  46,        512) /* DefaultCombatStyle - Magic */
+     , (50150,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (50150,  94,         16) /* TargetType - Creature */
+     , (50150, 150,        103) /* HookPlacement - Hook */
+     , (50150, 151,          2) /* HookType - Wall */
+     , (50150, 166,         31) /* SlayerCreatureType - Human */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (50150,  15, True ) /* LightsStatus */
+     , (50150,  22, True ) /* Inscribable */
+     , (50150,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (50150,  29,    1.05) /* WeaponDefense */
+     , (50150,  76,     0.2) /* Translucency */
+     , (50150, 138,     1.2) /* SlayerDamageBonus */	 
+     , (50150, 144,    0.05) /* ManaConversionMod */
+     , (50150, 147,    0.20) /* CriticalFrequency */;
+
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (50150,   1, 'PK Trophy Skull') /* Name */
+     , (50150,  16, 'The skull of an unknown low level victim.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (50150,   1, 0x0200101E) /* Setup */
+     , (50150,   3, 0x20000014) /* SoundTable */
+     , (50150,   8, 0x06002BC4) /* Icon */
+     , (50150,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (50150,  27, 0x400000E1) /* UseUserAnimation - UseMagicWand */;
+

--- a/Content/sql/weenies/50151 PK Trophy (Mid).sql
+++ b/Content/sql/weenies/50151 PK Trophy (Mid).sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 50151;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (50151, 'pktrophy_mid', 35, '2023-05-13 16:20:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (50151,   1,      32768) /* ItemType - Caster */
+     , (50151,   3,         14) /* PaletteTemplate - Red */
+     , (50151,   5,         50) /* EncumbranceVal */
+     , (50151,   8,         50) /* Mass */
+     , (50151,   9,   16777216) /* ValidLocations - Held */
+     , (50151,  16,    6291464) /* ItemUseable - SourceContainedTargetRemoteNeverWalk */
+     , (50151,  18,          1) /* UiEffects - Magical */
+     , (50151,  19,        666) /* Value */
+     , (50151,  46,        512) /* DefaultCombatStyle - Magic */
+     , (50151,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (50151,  94,         16) /* TargetType - Creature */
+     , (50151, 150,        103) /* HookPlacement - Hook */
+     , (50151, 151,          2) /* HookType - Wall */
+     , (50151, 166,         31) /* SlayerCreatureType - Human */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (50151,  15, True ) /* LightsStatus */
+     , (50151,  22, True ) /* Inscribable */
+     , (50151,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (50151,  29,    1.07) /* WeaponDefense */
+     , (50151,  76,     0.2) /* Translucency */
+     , (50151, 138,     1.4) /* SlayerDamageBonus */	 
+     , (50151, 144,    0.07) /* ManaConversionMod */
+     , (50151, 147,    0.25) /* CriticalFrequency */;
+
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (50151,   1, 'PK Trophy Skull') /* Name */
+     , (50151,  16, 'The skull of an unknown mid level victim.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (50151,   1, 0x0200101E) /* Setup */
+     , (50151,   3, 0x20000014) /* SoundTable */
+     , (50151,   8, 0x06001070) /* Icon */
+     , (50151,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (50151,  27, 0x400000E1) /* UseUserAnimation - UseMagicWand */;
+

--- a/Content/sql/weenies/50152 PK Trophy (High).sql
+++ b/Content/sql/weenies/50152 PK Trophy (High).sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 50152;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (50152, 'pktrophy_high', 35, '2023-05-13 16:20:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (50152,   1,      32768) /* ItemType - Caster */
+     , (50152,   3,         14) /* PaletteTemplate - Red */
+     , (50152,   5,         50) /* EncumbranceVal */
+     , (50152,   8,         50) /* Mass */
+     , (50152,   9,   16777216) /* ValidLocations - Held */
+     , (50152,  16,    6291464) /* ItemUseable - SourceContainedTargetRemoteNeverWalk */
+     , (50152,  18,          1) /* UiEffects - Magical */
+     , (50152,  19,        666) /* Value */
+     , (50152,  46,        512) /* DefaultCombatStyle - Magic */
+     , (50152,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (50152,  94,         16) /* TargetType - Creature */
+     , (50152, 150,        103) /* HookPlacement - Hook */
+     , (50152, 151,          2) /* HookType - Wall */
+     , (50152, 166,         31) /* SlayerCreatureType - Human */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (50152,  15, True ) /* LightsStatus */
+     , (50152,  22, True ) /* Inscribable */
+     , (50152,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (50152,  29,    1.09) /* WeaponDefense */
+     , (50152,  76,     0.2) /* Translucency */
+     , (50152, 136,     2.5) /* CriticalMultiplier */
+     , (50152, 138,     1.8) /* SlayerDamageBonus */	 
+     , (50152, 144,    0.09) /* ManaConversionMod */
+     , (50152, 147,    0.33) /* CriticalFrequency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (50152,   1, 'PK Trophy Skull') /* Name */
+     , (50152,  16, 'The skull of an unknown high level victim.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (50152,   1, 0x0200101E) /* Setup */
+     , (50152,   3, 0x20000014) /* SoundTable */
+     , (50152,   8, 0x06001EF3) /* Icon */
+     , (50152,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (50152,  27, 0x400000E1) /* UseUserAnimation - UseMagicWand */;
+

--- a/Content/sql/weenies/50153 PK Trophy (Extreme).sql
+++ b/Content/sql/weenies/50153 PK Trophy (Extreme).sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 50153;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (50153, 'pktrophy_extreme', 35, '2023-05-13 16:20:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (50153,   1,      32768) /* ItemType - Caster */
+     , (50153,   3,         14) /* PaletteTemplate - Red */
+     , (50153,   5,         50) /* EncumbranceVal */
+     , (50153,   8,         50) /* Mass */
+     , (50153,   9,   16777216) /* ValidLocations - Held */
+     , (50153,  16,    6291464) /* ItemUseable - SourceContainedTargetRemoteNeverWalk */
+     , (50153,  18,          1) /* UiEffects - Magical */
+     , (50153,  19,        666) /* Value */
+     , (50153,  46,        512) /* DefaultCombatStyle - Magic */
+     , (50153,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (50153,  94,         16) /* TargetType - Creature */
+     , (50153, 150,        103) /* HookPlacement - Hook */
+     , (50153, 151,          2) /* HookType - Wall */
+     , (50153, 166,         31) /* SlayerCreatureType - Human */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (50153,  15, True ) /* LightsStatus */
+     , (50153,  22, True ) /* Inscribable */
+     , (50153,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (50153,  29,    1.13) /* WeaponDefense */
+     , (50153,  76,     0.2) /* Translucency */
+     , (50153, 136,     3.0) /* CriticalMultiplier */
+     , (50153, 138,     2.0) /* SlayerDamageBonus */	 
+     , (50153, 144,    0.13) /* ManaConversionMod */
+     , (50153, 147,    0.33) /* CriticalFrequency */
+	 , (50153, 149,    1.03) /* WeaponMissileDefense */
+     , (50153, 150,    1.03) /* WeaponMagicDefense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (50153,   1, 'PK Trophy Skull') /* Name */
+     , (50153,  16, 'The skull of an unknown extreme level victim.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (50153,   1, 0x0200101E) /* Setup */
+     , (50153,   3, 0x20000014) /* SoundTable */
+     , (50153,   8, 0x06003773) /* Icon */
+     , (50153,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (50153,  27, 0x400000E1) /* UseUserAnimation - UseMagicWand */;
+

--- a/Content/sql/weenies/50154 Altar of the Iron Soul - hcswitch.sql
+++ b/Content/sql/weenies/50154 Altar of the Iron Soul - hcswitch.sql
@@ -1,0 +1,37 @@
+DELETE FROM `weenie` WHERE `class_Id` = 50154;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (50154, 'hcswitch', 27, '2023-05-14 16:20:00') /* HCModifier */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (50154,   1,        128) /* ItemType - Misc */
+     , (50154,   5,         50) /* EncumbranceVal */
+     , (50154,   8,         25) /* Mass */
+     , (50154,  16,         32) /* ItemUseable - Remote */
+     , (50154,  19,          0) /* Value */
+     , (50154,  93,       1040) /* PhysicsState - IgnoreCollisions, Gravity */
+     , (50154,  99,          1) /* PkLevelModifier */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (50154,     1, True ) /* Stuck */
+     , (50154,    13, False) /* Ethereal */
+	 , (50154, 10001, True ) /* Hardcore */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (50154,  39,     0.6) /* DefaultScale */
+     , (50154,  50,       0) /* MinimumTimeSincePk */
+     , (50154,  54,       5) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (50154,   1, 'Altar of the Iron Soul') /* Name */
+     , (50154,  15, 'Using this altar will permanently commit you to hardcore life as one of Bael''Zharon''s Elite Chosen, a perpetual Player Killer freed from the protection of Asheron''s magic, including the restorative power of the lifestone. This means that you can attack others freed in this manner, and they can attack you, and there is no second chance at life. There is no return from this choice.') /* ShortDesc */
+     , (50154,  18, 'You hear distant laughter of delight and welcome, as you join the ranks of those hardy souls freed forever from Asheron''s protective shackles.  You have become one of his Elite Chosen, a Hardcore Player Killer.') /* UseMessage */
+     , (50154,  22, 'You hear Bael''Zharon''s distant, familiar laughter, reminding you that you are already one of his Chosen, a Player Killer. ') /* ActivationFailure */
+     , (50154,  26, 'The altar simply remains silent.') /* UsePkServerError */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (50154,   1, 0x02000359) /* Setup */
+     , (50154,   2, 0x0900002E) /* MotionTable */
+     , (50154,   3, 0x20000034) /* SoundTable */
+     , (50154,   8, 0x0600134F) /* Icon */
+     , (50154,  25, 0x10000051) /* UseTargetSuccessAnimation - Twitch1 */;

--- a/Content/sql/weenies/51451 Dark Heart.sql
+++ b/Content/sql/weenies/51451 Dark Heart.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 51451;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (51451, 'ace51451-darkheart', 38, '2021-11-01 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (51451,   1,       2048) /* ItemType - Gem */
+     , (51451,   5,        919) /* EncumbranceVal */
+     , (51451,  11,          1) /* MaxStackSize */
+     , (51451,  12,          1) /* StackSize */
+     , (51451,  13,        919) /* StackUnitEncumbrance */
+     , (51451,  15,        653) /* StackUnitValue */
+     , (51451,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (51451,  19,        653) /* Value */
+     , (51451,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (51451,  94,      33025) /* TargetType - WeaponOrCaster */
+     , (51451, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (51451,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (51451,   1, 'Dark Heart') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (51451,   1, 0x020009C5) /* Setup */
+     , (51451,   3, 0x20000014) /* SoundTable */
+     , (51451,   6, 0x04000BF8) /* PaletteBase */
+     , (51451,   8, 0x06001F07) /* Icon */
+     , (51451,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (51451,  50, 0x060011F7) /* IconOverlay */;

--- a/Source/ACE.Common/GameConfiguration.cs
+++ b/Source/ACE.Common/GameConfiguration.cs
@@ -63,6 +63,11 @@ namespace ACE.Common
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public bool LandblockPreloading { get; set; }
 
+        [System.ComponentModel.DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool TestWorld { get; set; }
+
+
         public List<PreloadedLandblocks> PreloadedLandblocks { get; set; }
 
         /// <summary>

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -837,16 +837,14 @@ namespace ACE.Database
         /// <summary>
         /// This will get all player biotas that are backed by characters that are not deleted.
         /// </summary>
-        public List<ACE.Entity.Models.Biota> GetAllPlayerBiotasInParallel()
+        public List<ACE.Entity.Models.Biota> GetAllPlayerBiotasInParallel(bool includeDeleted = false)
         {
             var biotas = new ConcurrentBag<ACE.Entity.Models.Biota>();
 
             using (var context = new ShardDbContext())
             {
-                var results = context.Character
-                    .Where(r => !r.IsDeleted)
-                    .AsNoTracking()
-                    .ToList();
+                var results = includeDeleted ? context.Character.AsNoTracking().ToList()
+                    : context.Character.Where(r => !r.IsDeleted).AsNoTracking().ToList();
 
                 Parallel.ForEach(results, result =>
                 {

--- a/Source/ACE.Entity/Enum/ObjectDescriptionFlag.cs
+++ b/Source/ACE.Entity/Enum/ObjectDescriptionFlag.cs
@@ -17,6 +17,7 @@ namespace ACE.Entity.Enum
         Book                   = 0x00000100,
         Vendor                 = 0x00000200,
         PkSwitch               = 0x00000400,
+        HcSwitch               = 0x00000420,
         NpkSwitch              = 0x00000800,
         Door                   = 0x00001000,
         Corpse                 = 0x00002000,

--- a/Source/ACE.Entity/Enum/PKLevel.cs
+++ b/Source/ACE.Entity/Enum/PKLevel.cs
@@ -6,6 +6,6 @@ namespace ACE.Entity.Enum
         NPK     = 0,
         PK      = 1,
         PKLite  = 2,
-        Free    = 3,
+        Free    = 3
     }
 }

--- a/Source/ACE.Entity/Enum/PKLevel.cs
+++ b/Source/ACE.Entity/Enum/PKLevel.cs
@@ -6,6 +6,6 @@ namespace ACE.Entity.Enum
         NPK     = 0,
         PK      = 1,
         PKLite  = 2,
-        Free    = 3
+        Free    = 3,
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -205,6 +205,9 @@ namespace ACE.Entity.Enum.Properties
         VendorPKOnly                     = 9015,
         [ServerOnly]
         UseXpOverride                    = 9016,
+
+        // CustomDM
+        IsHardcore                       = 10001,
     }
 
     public static class PropertyBoolExtensions

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -871,7 +871,7 @@ namespace ACE.Server.Command.Handlers
         }
 
         // telepoi location
-        [CommandHandler("telepoi", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+        [CommandHandler("telepoi", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 1,
             "Teleport yourself to a named Point of Interest",
             "[POI|list]\n" +
             "@telepoi Arwic\n" +
@@ -879,6 +879,13 @@ namespace ACE.Server.Command.Handlers
             "@telepoi list")]
         public static void HandleTeleportPoi(Session session, params string[] parameters)
         {
+            if (!Common.ConfigManager.Config.Server.TestWorld && session.AccessLevel < AccessLevel.Developer)
+            {
+                ChatPacket.SendServerMessage(session, "You dont have access to this command",
+                    ChatMessageType.Broadcast);
+                return;
+            }
+
             var poi = String.Join(" ", parameters);
 
             if (poi.ToLower() == "list")
@@ -4584,9 +4591,16 @@ namespace ACE.Server.Command.Handlers
             HandleCISalvage(session, parameters);
         }
 
-        [CommandHandler("cisalvage", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Create a salvage bag in your inventory", "<material_type>, optional: <structure> <workmanship> <num_items>")]
+        [CommandHandler("cisalvage", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 1, "Create a salvage bag in your inventory", "<material_type>, optional: <structure> <workmanship> <num_items>")]
         public static void HandleCISalvage(Session session, params string[] parameters)
         {
+            if (!Common.ConfigManager.Config.Server.TestWorld && session.AccessLevel < AccessLevel.Developer)
+            {
+                ChatPacket.SendServerMessage(session, "You dont have access to this command",
+                    ChatMessageType.Broadcast);
+                return;
+            }
+
             if (!Enum.TryParse(parameters[0], true, out MaterialType materialType))
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't find material type {parameters[0]}", ChatMessageType.Broadcast));

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -782,9 +782,16 @@ namespace ACE.Server.Command.Handlers
         // Experience
         // ==================================
 
-        [CommandHandler("grantxp", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Give XP to yourself (or the specified character).", "ulong\n" + "@grantxp [name] 191226310247 is max level 275")]
+        [CommandHandler("grantxp", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 1, "Give XP to yourself (or the specified character).", "ulong\n" + "@grantxp [name] 191226310247 is max level 275")]
         public static void HandleGrantXp(Session session, params string[] parameters)
         {
+            if(!Common.ConfigManager.Config.Server.TestWorld && session.AccessLevel < AccessLevel.Developer)
+            {
+                ChatPacket.SendServerMessage(session, "You dont have access to this command",
+                    ChatMessageType.Broadcast);
+                return;
+            }
+
             if (parameters?.Length > 0)
             {
                 List<CommandParameterHelpers.ACECommandParameter> aceParams = new List<CommandParameterHelpers.ACECommandParameter>()
@@ -2962,9 +2969,16 @@ namespace ACE.Server.Command.Handlers
             session.Network.EnqueueSend(new GameMessageSystemChat(session.Player.DamageHistory.ToString(), ChatMessageType.Broadcast));
         }
 
-        [CommandHandler("remove-vitae", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Removes vitae from last appraised player")]
+        [CommandHandler("remove-vitae", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Removes vitae from last appraised player")]
         public static void HandleRemoveVitae(Session session, params string[] parameters)
         {
+            if (!Common.ConfigManager.Config.Server.TestWorld && session.AccessLevel < AccessLevel.Developer)
+            {
+                ChatPacket.SendServerMessage(session, "You dont have access to this command",
+                    ChatMessageType.Broadcast);
+                return;
+            }
+
             var player = CommandHandlerHelper.GetLastAppraisedObject(session) as Player;
 
             if (player == null)

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -17,7 +17,6 @@ using ACE.Server.WorldObjects;
 using System.Linq;
 using System.Text;
 
-
 namespace ACE.Server.Command.Handlers
 {
     public static class PlayerCommands

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -372,14 +372,14 @@ namespace ACE.Server.Entity
             // armor rending and cleaving
             var armorRendingMod = 1.0f;
             if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending))
-                armorRendingMod = WorldObject.GetArmorRendingMod(attackSkill);
+                armorRendingMod = WorldObject.GetArmorRendingMod(attackSkill, pkBattle);
 
             var armorCleavingMod = attacker.GetArmorCleavingMod(Weapon);
 
             var ignoreArmorMod = Math.Min(armorRendingMod, armorCleavingMod);
 
-            if (Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM && pkBattle)
-                ignoreArmorMod *= 0.7f; // Armor is reduced during PvP.
+            //if (Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM && pkBattle)
+            //    ignoreArmorMod *= 0.7f; // Armor is reduced during PvP.
 
             // get body part / armor pieces / armor modifier
             if (playerDefender != null)
@@ -413,7 +413,7 @@ namespace ACE.Server.Entity
                 ArmorMod = 1.0f;
 
             // get resistance modifiers
-            WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(Weapon, attacker, attackSkill, DamageType);
+            WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(Weapon, attacker, attackSkill, DamageType, pkBattle);
 
             if (playerDefender != null)
             {

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -528,7 +528,8 @@ namespace ACE.Server.Entity
         {
             // https://asheron.fandom.com/wiki/Announcements_-_2002/02_-_Fever_Dreams#Letter_to_the_Players_1
 
-            var fellowshipMembers = GetFellowshipMembers();
+            // Share with same player types only
+            Dictionary<uint, Player> fellowshipMembers = GetLikeFellowshipMembers(player);
 
             shareType &= ~ShareType.Fellowship;
 
@@ -769,6 +770,34 @@ namespace ACE.Server.Entity
 
                 if (player != null && player.Session != null && player.Session.Player != null && player.Fellowship != null)
                     results.Add(playerGuid, player);
+                else
+                    dropped.Add(playerGuid);
+            }
+
+            // TODO: process dropped list
+            if (dropped.Count > 0)
+                ProcessDropList(FellowshipMembers, dropped);
+
+            return results;
+        }
+
+        public Dictionary<uint, Player> GetLikeFellowshipMembers(Player me)
+        {
+            var results = new Dictionary<uint, Player>();
+            var dropped = new HashSet<uint>();
+
+            foreach (var kvp in FellowshipMembers)
+            {
+                var playerGuid = kvp.Key;
+                var playerRef = kvp.Value;
+
+                playerRef.TryGetTarget(out var player);
+
+                if (player != null && player.Session != null && player.Session.Player != null && player.Fellowship != null)
+                {
+                    if (me.IsHardcore == player.IsHardcore)
+                        results.Add(playerGuid, player);
+                }
                 else
                     dropped.Add(playerGuid);
             }

--- a/Source/ACE.Server/Entity/IPlayer.cs
+++ b/Source/ACE.Server/Entity/IPlayer.cs
@@ -50,6 +50,7 @@ namespace ACE.Server.Entity
 
         int? Gender { get; }
 
+        bool IsHardcore { get; }
 
         bool IsDeleted { get; }
         bool IsPendingDeletion { get; }

--- a/Source/ACE.Server/Entity/OfflinePlayer.cs
+++ b/Source/ACE.Server/Entity/OfflinePlayer.cs
@@ -187,6 +187,10 @@ namespace ACE.Server.Entity
 
         public int? Gender => GetProperty(PropertyInt.Gender);
 
+        public bool IsHardcore
+        {
+            get => GetProperty(PropertyBool.IsHardcore) ?? false;
+        }
 
         public uint? MonarchId
         {

--- a/Source/ACE.Server/Entity/Tailoring.cs
+++ b/Source/ACE.Server/Entity/Tailoring.cs
@@ -212,6 +212,12 @@ namespace ACE.Server.Entity
 
             var wo = WorldObjectFactory.CreateNewWorldObject(wcid.Value);
 
+            if(wo == null)
+            {
+                player.SendUseDoneEvent(WeenieError.ActionCancelled);
+                return;
+            }
+
             SetArmorProperties(target, wo);
 
             player.Session.Network.EnqueueSend(new GameMessageSystemChat("You tailor the appearance off an existing piece of armor.", ChatMessageType.Broadcast));
@@ -221,6 +227,10 @@ namespace ACE.Server.Entity
 
         public static void SetCommonProperties(WorldObject source, WorldObject target)
         {
+
+            if (target == null)
+                return;
+
             // a lot of this was probably done with recipes and mutations in the original
             // here a lot is done directly in code..
 
@@ -257,6 +267,9 @@ namespace ACE.Server.Entity
 
         public static void SetArmorProperties(WorldObject source, WorldObject target)
         {
+            if (target == null)
+                return;
+
             SetCommonProperties(source, target);
 
             // ensure armor/clothing that covers head/hands/feet are cross-compatible
@@ -280,6 +293,9 @@ namespace ACE.Server.Entity
         /// </summary>
         public static void SetWeaponProperties(WorldObject source, WorldObject target)
         {
+            if(target == null)
+                return;
+
             SetCommonProperties(source, target);
 
             target.TargetType = source.ItemType;
@@ -372,6 +388,13 @@ namespace ACE.Server.Entity
 
             // create intermediate weapon tailoring kit
             var wo = WorldObjectFactory.CreateNewWorldObject(DarkHeart);
+
+            if (wo == null)
+            {
+                player.SendUseDoneEvent(WeenieError.ActionCancelled);
+                return;
+            }
+
             SetWeaponProperties(target, wo);
 
             player.Session.Network.EnqueueSend(new GameMessageSystemChat("You tailor the appearance off the weapon.", ChatMessageType.Broadcast));

--- a/Source/ACE.Server/Factories/Tables/Wcids/SpecialItemsWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SpecialItemsWcids.cs
@@ -23,10 +23,15 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         private static Dictionary<WeenieClassName, int> specialItemsUnmutatedAmount = new Dictionary<WeenieClassName, int>()
         {
-            {(WeenieClassName)50128,      10 }, // Spell Extraction Scroll VI
-            {(WeenieClassName)50129,      10 }, // Spell Extraction Scroll VII
-            {(WeenieClassName)50140,       1 }, // Minor Cantrip Extraction Scroll
-            {(WeenieClassName)50141,       1 }, // Major Cantrip Extraction Scroll
+            {(WeenieClassName)50128,      20 }, // Spell Extraction Scroll VI
+            {(WeenieClassName)50129,      20 }, // Spell Extraction Scroll VII
+            {(WeenieClassName)50140,       5 }, // Minor Cantrip Extraction Scroll
+            {(WeenieClassName)50141,       5 }, // Major Cantrip Extraction Scroll
+            {(WeenieClassName)11475,       5 }, // Black dye pot
+            {(WeenieClassName)7299,       10 }, // Diamond Scarabs
+            {(WeenieClassName)22499,       2 }, // Plentiful Healing kits
+            {(WeenieClassName)51445,       1 }, // Weapon tailoring kit
+            {(WeenieClassName)41956,       1 }, // Armor tailoring kit
         };
 
         private static ChanceTable<WeenieClassName> specialItemsSalvageWcids = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)

--- a/Source/ACE.Server/Factories/Tables/Wcids/SpecialItemsWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SpecialItemsWcids.cs
@@ -19,6 +19,12 @@ namespace ACE.Server.Factories.Tables.Wcids
             ((WeenieClassName)50129,      1.00f ), // Spell Extraction Scroll VII
             ((WeenieClassName)50140,      1.00f ), // Minor Cantrip Extraction Scroll
             ((WeenieClassName)50141,      1.00f ), // Major Cantrip Extraction Scroll
+            ((WeenieClassName)11475,      1.00f ), // Black Dye Pot
+            ((WeenieClassName)7299,       1.00f ), // Diamond Scarabs
+            ((WeenieClassName)22499,      1.00f ), // Plentiful Healin Kits
+            ((WeenieClassName)51445,      1.00f ), // Weapon Tailoring Kit
+            ((WeenieClassName)41956,      1.00f ), // Armor Tailoring Kit
+            ((WeenieClassName)29273,      1.00f ), // Weapon Imbue Augmentation Gem
         };
 
         private static Dictionary<WeenieClassName, int> specialItemsUnmutatedAmount = new Dictionary<WeenieClassName, int>()
@@ -32,6 +38,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             {(WeenieClassName)22499,       2 }, // Plentiful Healing kits
             {(WeenieClassName)51445,       1 }, // Weapon tailoring kit
             {(WeenieClassName)41956,       1 }, // Armor tailoring kit
+            {(WeenieClassName)29273,       1 }, // Weapon imbue augmentation gem
         };
 
         private static ChanceTable<WeenieClassName> specialItemsSalvageWcids = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
@@ -41,12 +48,12 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.materialiron,             3.00f ), // Weapon Damage + 1
             ( WeenieClassName.materialmahogany,         3.00f ), // Missile Weapon Mod + 4%
 
-            ( WeenieClassName.materialcarnelian,        2.00f ), // Minor Strength
-            ( WeenieClassName.materialsmokyquartz,      2.00f ), // Minor Coordination
-            ( WeenieClassName.materialbloodstone,       2.00f ), // Minor Endurance
-            ( WeenieClassName.materialrosequartz,       2.00f ), // Minor Quickness
-            ( WeenieClassName.materialagate,            2.00f ), // Minor Focus
-            ( WeenieClassName.materiallapislazuli,      2.00f ), // Minor Willpower
+            //( WeenieClassName.materialcarnelian,        2.00f ), // Minor Strength
+            //( WeenieClassName.materialsmokyquartz,      2.00f ), // Minor Coordination
+            //( WeenieClassName.materialbloodstone,       2.00f ), // Minor Endurance
+            //( WeenieClassName.materialrosequartz,       2.00f ), // Minor Quickness
+            //( WeenieClassName.materialagate,            2.00f ), // Minor Focus
+            //( WeenieClassName.materiallapislazuli,      2.00f ), // Minor Willpower
 
             ( WeenieClassName.materialmalachite,        2.00f ), // Warrior's Vigor
             ( WeenieClassName.materialhematite,         2.00f ), // Warrior's Vitality

--- a/Source/ACE.Server/Managers/CampManager.cs
+++ b/Source/ACE.Server/Managers/CampManager.cs
@@ -307,6 +307,11 @@ namespace ACE.Server.Managers
             if (camp.CampId == 0)
                 decayRate = DecayRateRest; // Rest camp decays at a higher rate
 
+            if (camp.CampId > 0xFFFF0000 && Player.IsHardcore) // Hardcore turn-ins decay slower
+            {
+                decayRate *= (float)0.5;
+            }
+
             uint amountToDecay = (uint)Math.Max(Math.Floor((secondsSinceLastCheck - DelayBeforeDecayStart) / decayRate), 0);
 
             if (amountToDecay > 0)
@@ -391,7 +396,14 @@ namespace ACE.Server.Managers
                 {
                     CheckDecay(typeCamp, true);
                     typeCampBonus = 1.0f - ((float)typeCamp.NumInteractions / GetMaxInteractions(typeCamp.CampId));
-                    Increment(typeCamp);
+                    if (typeCampId > 0xFFFF0000 && Player.IsHardcore) // Turn-in Type Camp
+                    {
+                        Increment(typeCamp, 5);
+                    }
+                    else
+                    {
+                        Increment(typeCamp);
+                    }
                 }
             }
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -730,7 +730,8 @@ namespace ACE.Server.Managers
                 ("server_motd4", new Property<string>("", "Server message of the day - Fourth message")),
                 ("turbine_chat_webhook", new Property<string>("", "Webhook to be used for turbine chat. This is for copying ingame general chat channels to a Discord channel.")),
                 ("turbine_chat_webhook_audit", new Property<string>("", "Webhook to be used for ingame audit log.")),
-                ("proxycheck_api_key", new Property<string>("", "API key for proxycheck.io service for VPN detection"))
+                ("proxycheck_api_key", new Property<string>("", "API key for proxycheck.io service for VPN detection")),
+                ("vpn_account_whitelist", new Property<string>("", "A comma separated list of account names for which VPN detection is bypassed"))
                 );
     }
 }

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -381,7 +381,7 @@ namespace ACE.Server.Managers
                 return;
             }
 
-            var roll = ThreadSafeRandom.Next(0.0f, 1.0f);
+            var roll = new Random().NextDouble();
             var success = roll < successChance;
             log.Info($"Player = { player.Name}; Tool = { source.Name}; Target = { target.Name}; Chance = {successChance}; Roll = {roll}");
 
@@ -1067,8 +1067,8 @@ namespace ACE.Server.Managers
             var destroyTargetChance = success ? recipe.SuccessDestroyTargetChance : recipe.FailDestroyTargetChance;
             var destroySourceChance = success ? recipe.SuccessDestroySourceChance : recipe.FailDestroySourceChance;
 
-            var destroyTarget = ThreadSafeRandom.Next(0.0f, 1.0f) < destroyTargetChance;
-            var destroySource = ThreadSafeRandom.Next(0.0f, 1.0f) < destroySourceChance;
+            var destroyTarget = new Random().NextDouble() < destroyTargetChance;
+            var destroySource = new Random().NextDouble() < destroySourceChance;
 
             var createItem = success ? recipe.SuccessWCID : recipe.FailWCID;
             var createAmount = success ? recipe.SuccessAmount : recipe.FailAmount;

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -223,7 +223,16 @@ namespace ACE.Server.Network.Handlers
                 }
 
                 //Disallow VPN connections
-                if (PropertyManager.GetBool("block_vpn_connections").Item)
+                bool isAccountVpnWhitelisted = false;
+                var whitelist = PropertyManager.GetString("vpn_account_whitelist").Item.Split(",");
+                if(whitelist != null && whitelist.Length > 0)
+                {
+                    var match = whitelist.FirstOrDefault(account.AccountName);
+                    if (match != null)
+                        isAccountVpnWhitelisted = true;
+                }
+
+                if (PropertyManager.GetBool("block_vpn_connections").Item && !isAccountVpnWhitelisted)
                 {
                     try
                     {

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -115,7 +115,9 @@ namespace ACE.Server.Network.Managers
                         log.DebugFormat("Login Request from {0}", endPoint);
 
                         var ipAllowsUnlimited = ConfigManager.Config.Server.Network.AllowUnlimitedSessionsFromIPAddresses.Contains(endPoint.Address.ToString());
-                        if (ipAllowsUnlimited || ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress == -1 || GetSessionEndpointTotalByAddressCount(endPoint.Address) < ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress)
+                        var withinAllowedCount = ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress == -1
+                                         || GetSessionEndpointTotalByAddressCount(endPoint.Address) < ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress;
+                        if (ipAllowsUnlimited || withinAllowedCount)
                         {
                             var session = FindOrCreateSession(connectionListener, endPoint);
                             if (session != null)

--- a/Source/ACE.Server/WorldObjects/Clothing.cs
+++ b/Source/ACE.Server/WorldObjects/Clothing.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
 using ACE.Entity;

--- a/Source/ACE.Server/WorldObjects/Clothing.cs
+++ b/Source/ACE.Server/WorldObjects/Clothing.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Linq;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
 using ACE.Entity;
@@ -35,11 +35,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void SetProperties(int palette, double shade)
         {
-            var icon = DatManager.PortalDat.ReadFromDat<ClothingTable>(GetProperty(PropertyDataId.ClothingBase) ?? 0).GetIcon((uint)palette);
-
-            SetProperty(PropertyDataId.Icon, icon);
-            SetProperty(PropertyInt.PaletteTemplate, palette);
-            SetProperty(PropertyFloat.Shade, shade);
+            this.PaletteTemplate = palette;
+            this.Shade = shade;
+            this.IconId = DatManager.PortalDat.ReadFromDat<ClothingTable>(GetProperty(PropertyDataId.ClothingBase) ?? 0).GetIcon((uint)palette);                    
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -862,16 +862,16 @@ namespace ACE.Server.WorldObjects
             //if (effectiveSL < 0 && effectiveRL != 0)
                 //effectiveRL = 1.0f / effectiveRL;
 
-            var effectiveLevel = effectiveSL * effectiveRL;
+            var effectiveLevel = GetSkillModifiedShieldLevel(effectiveSL);
 
-            effectiveLevel = GetSkillModifiedShieldLevel(effectiveLevel);
+            effectiveLevel *= effectiveRL;
 
             var ignoreShieldMod = attacker.GetIgnoreShieldMod(weapon);
             //Console.WriteLine($"IgnoreShieldMod: {ignoreShieldMod}");
 
-            var pkBattle = player != null && attacker is Player;
-            if (Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM && pkBattle)
-                ignoreShieldMod *= 0.7f; // Armor is reduced during PvP.
+            //var pkBattle = player != null && attacker is Player;
+            //if (Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM && pkBattle)
+            //    ignoreShieldMod *= 0.7f; // Armor is reduced during PvP.
 
             effectiveLevel *= ignoreShieldMod;
 

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -445,9 +445,15 @@ namespace ACE.Server.WorldObjects
 
             // life spells
             // additive: armor/imperil
-            var bodyArmorMod = defender.EnchantmentManager.GetBodyArmorMod();
-            if (ignoreMagicResist && Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM)
-                bodyArmorMod = IgnoreMagicResistScaled(bodyArmorMod);
+            int bodyArmorMod;
+            if (Common.ConfigManager.Config.Server.WorldRuleset == Common.Ruleset.CustomDM)
+                bodyArmorMod = defender.EnchantmentManager.GetBodyArmorMod(true); // Do not take into account armor debuffs yet.
+            else
+            {
+                bodyArmorMod = defender.EnchantmentManager.GetBodyArmorMod();
+                if (ignoreMagicResist)
+                    bodyArmorMod = IgnoreMagicResistScaled(bodyArmorMod);
+            }
 
             // handle armor rending mod here?
             //if (bodyArmorMod > 0)
@@ -460,10 +466,11 @@ namespace ACE.Server.WorldObjects
                 effectiveAL += bodyArmorMod;
             else
             {
-                if (!ignoreMagicResist)
-                    effectiveAL += defender.EnchantmentManager.GetBodyArmorMod(false); // Take into account armor debuffs.
                 if (bodyArmorMod > effectiveAL)
                     effectiveAL = bodyArmorMod; // Body armor doesn't stack with equipment armor, use whichever is highest.
+
+                if (!ignoreMagicResist)
+                    effectiveAL += defender.EnchantmentManager.GetBodyArmorMod(false); // Take into account armor debuffs now, but only if weapon isn't hollow.
             }
 
             // Armor Rending reduces physical armor too?

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -460,7 +460,8 @@ namespace ACE.Server.WorldObjects
                 effectiveAL += bodyArmorMod;
             else
             {
-                effectiveAL += defender.EnchantmentManager.GetBodyArmorMod(false); // Take into account armor debuffs.
+                if (!ignoreMagicResist)
+                    effectiveAL += defender.EnchantmentManager.GetBodyArmorMod(false); // Take into account armor debuffs.
                 if (bodyArmorMod > effectiveAL)
                     effectiveAL = bodyArmorMod; // Body armor doesn't stack with equipment armor, use whichever is highest.
             }
@@ -614,7 +615,7 @@ namespace ACE.Server.WorldObjects
             Console.WriteLine("Effective RL: " + effectiveRL);
             Console.WriteLine();*/
 
-            return GetSkillModifiedArmorLevel(effectiveAL * effectiveRL);
+            return GetSkillModifiedArmorLevel(effectiveAL) * effectiveRL;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/PKModifier.cs
+++ b/Source/ACE.Server/WorldObjects/PKModifier.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using ACE.Common;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;

--- a/Source/ACE.Server/WorldObjects/PKModifier.cs
+++ b/Source/ACE.Server/WorldObjects/PKModifier.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using ACE.Common;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
@@ -165,6 +166,17 @@ namespace ACE.Server.WorldObjects
             {
                 player.SetProperty(PropertyBool.IsHardcore, true);
                 player.AddTitle(203, true); //ID_CharacterTitle_Cursed_Adventurer
+
+                var shirt = player.GetEquippedClothingArmor(CoverageMask.UnderwearChest).FirstOrDefault();
+                player.TryDequipObjectWithNetworking(shirt.Guid, out shirt, Player.DequipObjectAction.DequipToPack);
+                shirt.PaletteTemplate = (int?)ACE.Entity.Enum.PaletteTemplate.Red;
+                shirt.Shade = 1.0f;
+                shirt.Dyable = false;
+                shirt.LongDesc = "An official red shirt worn with pride by Hardcore initiates on important missions.";
+                player.TryEquipObjectWithNetworking(shirt, shirt.ValidLocations ?? 0);
+                player.Session.Network.EnqueueSend(new GameMessageUpdateObject(shirt));
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat("Oh... an official red shirt!", ChatMessageType.Tell));
+
             }
 
             if ((player.PkLevel == PKLevel.NPK && IsPKSwitch) || (player.PkLevel == PKLevel.PK && IsNPKSwitch))

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -109,6 +109,9 @@ namespace ACE.Server.WorldObjects
 
         public DateTime PrevObjSend;
         public DateTime PrevWho;
+        public DateTime PrevHCAll;
+        public DateTime PrevHCLiving;
+        public DateTime PrevHCPvP;
 
         public float CurrentRadarRange => Location.Indoors ? MaxRadarRange_Indoors : MaxRadarRange_Outdoors;
 

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -582,7 +582,7 @@ namespace ACE.Server.WorldObjects
                     }
                 }
 
-                var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
+                var rng = new Random().NextDouble();
                 if (chance > rng)
                     castingPreCheckStatus = CastingPreCheckStatus.Success;
             }
@@ -969,7 +969,7 @@ namespace ACE.Server.WorldObjects
                                 var currentTime = Time.GetUnixTime();
                                 if (amulet.LeyLineTriggerChance == 1.0f || amulet.NextLeyLineTriggerTime <= currentTime)
                                 {
-                                    var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
+                                    var rng = new Random().NextDouble();
                                     if (amulet.LeyLineTriggerChance > rng)
                                     {
                                         amulet.NextLeyLineTriggerTime = currentTime + LeyLineAmulet.LeyLineTriggerInterval;

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -294,6 +294,11 @@ namespace ACE.Server.WorldObjects
             set { if (!value) RemoveProperty(PropertyBool.LoginAtLifestone); else SetProperty(PropertyBool.LoginAtLifestone, value); }
         }
 
+        public bool IsHardcore
+        {
+            get => GetProperty(PropertyBool.IsHardcore) ?? false;
+        }
+
         /*public bool IsOlthoiPlayer()
         {
             switch (WeenieClassId)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -514,14 +514,14 @@ namespace ACE.Server.WorldObjects
 
                 // could life magic projectiles crit?
                 // if so, did they use the same 1.5x formula as war magic, instead of 2.0x?
-                if (criticalHit)
-                {
-                    // verify: CriticalMultiplier only applied to the additional crit damage,
-                    // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-                    weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
+                //if (criticalHit)
+               // {
+               //     // verify: CriticalMultiplier only applied to the additional crit damage,
+               //     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
+               //     weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
-                    critDamageBonus = lifeMagicDamage * 0.5f * weaponCritDamageMod;
-                }
+               //     critDamageBonus = lifeMagicDamage * 0.5f * weaponCritDamageMod;
+               // }
 
                 weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -512,7 +512,7 @@ namespace ACE.Server.WorldObjects
             {
                 lifeMagicDamage = LifeProjectileDamage * Spell.DamageRatio;
 
-                if (Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM)
+                if (!isPVP)
                 {
                     // could life magic projectiles crit?
                     // if so, did they use the same 1.5x formula as war magic, instead of 2.0x?

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -512,7 +512,7 @@ namespace ACE.Server.WorldObjects
             {
                 lifeMagicDamage = LifeProjectileDamage * Spell.DamageRatio;
 
-                if (!isPVP)
+                if (!isPVP || Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM)
                 {
                     // could life magic projectiles crit?
                     // if so, did they use the same 1.5x formula as war magic, instead of 2.0x?

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -512,16 +512,19 @@ namespace ACE.Server.WorldObjects
             {
                 lifeMagicDamage = LifeProjectileDamage * Spell.DamageRatio;
 
-                // could life magic projectiles crit?
-                // if so, did they use the same 1.5x formula as war magic, instead of 2.0x?
-                //if (criticalHit)
-               // {
-               //     // verify: CriticalMultiplier only applied to the additional crit damage,
-               //     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-               //     weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
+                if (Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM)
+                {
+                    // could life magic projectiles crit?
+                    // if so, did they use the same 1.5x formula as war magic, instead of 2.0x?
+                    if (criticalHit)
+                    {
+                        // verify: CriticalMultiplier only applied to the additional crit damage,
+                        // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
+                        weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
-               //     critDamageBonus = lifeMagicDamage * 0.5f * weaponCritDamageMod;
-               // }
+                        critDamageBonus = lifeMagicDamage * 0.5f * weaponCritDamageMod;
+                    }
+                }
 
                 weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
 

--- a/Source/ACE.Server/WorldObjects/SpellTransferScroll.cs
+++ b/Source/ACE.Server/WorldObjects/SpellTransferScroll.cs
@@ -75,7 +75,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (!RecipeManager.VerifyUse(player, source, target, true) || target.Workmanship == null || target.Retained == true)
+            if (!RecipeManager.VerifyUse(player, source, target, true) || target.Workmanship == null)
             {
                 player.SendUseDoneEvent(WeenieError.YouDoNotPassCraftingRequirements);
                 return;
@@ -323,7 +323,13 @@ namespace ACE.Server.WorldObjects
                 player.NextUseTime = DateTime.UtcNow.AddSeconds(animTime);
             }
             else // Extraction Scroll
-            {
+                       {
+                if (target.Retained == true)
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"The {target.NameWithMaterial} is Retained!.", ChatMessageType.Craft));
+                    player.SendUseDoneEvent();
+                    return;
+                }
                 int spellCount = 0;
                 var allSpells = target.Biota.GetKnownSpellsIds(target.BiotaDatabaseLock);
                 if (target.ProcSpell != null && target.ProcSpell != 0)

--- a/Source/ACE.Server/WorldObjects/SpellTransferScroll.cs
+++ b/Source/ACE.Server/WorldObjects/SpellTransferScroll.cs
@@ -242,7 +242,7 @@ namespace ACE.Server.WorldObjects
 
                 actionChain.AddAction(player, () =>
                 {
-                    var success = ThreadSafeRandom.Next(0.0f, 1.0f) < chance;
+                    var success = new Random().NextDouble() < chance;
                     if (success)
                     {
                         if (isProc)
@@ -403,7 +403,7 @@ namespace ACE.Server.WorldObjects
 
                 actionChain.AddAction(player, () =>
                 {
-                    var success = ThreadSafeRandom.Next(0.0f, 1.0f) < chance;
+                    var success = new Random().NextDouble() < chance;
                     var spellName = "a spell";
                     if (success)
                     {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2484,6 +2484,12 @@ namespace ACE.Server.WorldObjects
             set { SetProperty(PropertyInt.PlayerKillerStatus, (int)value); }
         }
 
+        public bool HardCoreModifier
+        {
+            get => GetProperty(PropertyBool.IsHardcore) ?? false;
+            set { SetProperty(PropertyBool.IsHardcore, true); } // no un-do
+        }
+
         public CloakStatus CloakStatus
         {
             get => (CloakStatus)(GetProperty(PropertyInt.CloakStatus) ?? 0);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -446,11 +446,26 @@ namespace ACE.Server.WorldObjects
             if (weapon != null && weapon.SlayerCreatureType != null && weapon.SlayerDamageBonus != null &&
                 target != null && weapon.SlayerCreatureType == target.CreatureType)
             {
-                // TODO: scale with base weapon skill?
+                if (Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM &&
+                    weapon.SlayerCreatureType == ACE.Entity.Enum.CreatureType.Human)
+                {
+                    var playerAttacker = wielder as Player;
+                    var playerDefender = target as Player;
+
+                    if (playerAttacker != null && playerDefender != null)
+                    {
+                        if (weapon.ItemType == ItemType.Caster)
+                            return 1.2f;
+                        else if (weapon.ItemType == ItemType.MissileWeapon)
+                            return 2.9f;
+                        else if (weapon.ItemType == ItemType.MeleeWeapon)
+                            return 3.4f;
+                    }
+                }
                 return (float)weapon.SlayerDamageBonus;
             }
-            else
-                return defaultModifier;
+
+            return defaultModifier;
         }
 
         public DamageType? ResistanceModifierType

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -446,26 +446,11 @@ namespace ACE.Server.WorldObjects
             if (weapon != null && weapon.SlayerCreatureType != null && weapon.SlayerDamageBonus != null &&
                 target != null && weapon.SlayerCreatureType == target.CreatureType)
             {
-                if (Common.ConfigManager.Config.Server.WorldRuleset != Common.Ruleset.CustomDM &&
-                    weapon.SlayerCreatureType == ACE.Entity.Enum.CreatureType.Human)
-                {
-                    var playerAttacker = wielder as Player;
-                    var playerDefender = target as Player;
-
-                    if (playerAttacker != null && playerDefender != null)
-                    {
-                        if (weapon.ItemType == ItemType.Caster)
-                            return 1.2f;
-                        else if (weapon.ItemType == ItemType.MissileWeapon)
-                            return 2.9f;
-                        else if (weapon.ItemType == ItemType.MeleeWeapon)
-                            return 3.4f;
-                    }
-                }
+                // TODO: scale with base weapon skill?
                 return (float)weapon.SlayerDamageBonus;
             }
-
-            return defaultModifier;
+            else
+                return defaultModifier;
         }
 
         public DamageType? ResistanceModifierType


### PR DESCRIPTION
_Submitted for feedback on the concept and implementation._

Create a hardcore character by creating 50154 (Altar of the Iron Soul) and activating the item. Suggest placing this in the Training Academy.

**Hardcore characters:**

- Are perma-red
- Must be flagged at level 3 or earlier
- One logged in character per IP
- Do not share XP with non-hardcore fellowship members
- Receive no pass-up XP, but generate pass-up XP at 3x the normal rate
- Drop 25% more items upon death in PvP
- Drop a hookable trophy describing the circumstances of their PvP death
- Are deleted without option of non-admin recovery upon death of any kind (PvE, PvP, bug, or crash)
- Have greatly accelerated penalty (5x) and greatly decreased (50%) TAR penalty decay for trophy turn-ins
- Hardcore earns double Xp for damage inflicted in a PvP kill
- Hardcore vs Hardcore bonus XP
-- Level up highlander style when killing a hardcore player who is a higher level  or 80+
-- 50%-80% of level XP if levels are within 5
-- 25%-50% of level XP if level is over 20 and not more than 10 different ** No bonus if killing lower level under 20 or more than 10 different

Related Changes:
- Helping kill a player 10 levels junior and under 80 accrues 2% Vitae
- Top damager killing a player 10 levels junior who is under 80 accrues 1% vitae per 5 levels difference

New Commands:

@hc_leaders_all
Reports on the top 13 all-time Hardcore characters by total XP

@hc_leaders_now
Reports on the top 13 living Hardcore characters by total XP

@hc_pk_board_all
Reports on the top 13 Hardcore characters ranked by PvP kills