### PR TITLE
Raise exploration contract salvage reward tier by 1 (determines workmanship of salvage bags)

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Contracts.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Contracts.cs
@@ -230,7 +230,7 @@ namespace ACE.Server.WorldObjects
             {
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"{sourceObject.Name} tells you, \"Here's your reward for the completed assignments:\"", ChatMessageType.Tell));
 
-                var rewardTier = Math.Clamp(RollTier(CalculateExtendedTier(Level ?? 1)) + 1, 1, 7);
+                var rewardTier = Math.Clamp(RollTier(CalculateExtendedTier(Level ?? 1)) + 2, 1, 7);
                 int rewardAmount;
 
                 if (assignment1Complete)


### PR DESCRIPTION
Rewards are based on character level at time of turn in

Before:
Level 1-9: 2.0
Level 10-29: 2.0-3.0
Level 30-49: 3.0-4.0
Level 50-99: 4.0-5.0
Level 100-119: 5.0-6.0
Level 120-180: 6.0-7.0
180+: 7.0

After:
Level 1-9: 3.0
Level 10-29: 3.0-4.0
Level 30-49: 4.0-5.0
Level 50-99: 5.0-6.0
Level 100-120: 6.0-7.0
Level 120+: 7.0