### PR TITLE
Add dekaru_hc_keep_non_equippable_bonded_on_death config to allow bonded items to be kept on HC death if non equippable

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -682,8 +682,9 @@ namespace ACE.Server.Managers
                 ("show_discord_chat_ingame", new Property<bool>(false, "Display messages posted to Discord in general chat")),
 
                 ("fall_damage_enabled", new Property<bool>(true, "Toggles whether fall damage is enabled")),
-                ("dekaru_dual_wield_speed_mod", new Property<bool>(true, "Toggles whether Dekaru's dual wield speed changes (other than for dagger) are enabled"))
-
+                ("dekaru_dual_wield_speed_mod", new Property<bool>(true, "Toggles whether Dekaru's dual wield speed changes (other than for dagger) are enabled")),
+                ("dekaru_hc_keep_non_equippable_bonded_on_death", new Property<bool>(true, "Toggles whether bonded items are kept on a hardcore death despite being non-equippable"))
+                
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 
 using ACE.Common.Extensions;
@@ -1129,6 +1130,7 @@ namespace ACE.Server.WorldObjects
             var inventory = GetAllPossessions();
             var inventoryToDelete = new List<WorldObject>();
 
+            var keepNonEquippable = PropertyManager.GetBool("dekaru_hc_keep_non_equippable_bonded_on_death").Item;
             foreach (var item in inventory)
             {
                 if (keepHousing && item.WeenieType == WeenieType.Deed) // Keep houses
@@ -1139,7 +1141,7 @@ namespace ACE.Server.WorldObjects
                 }
 
                 if (keepBondedEquipment
-                    && (item.ValidLocations ?? EquipMask.None) != EquipMask.None && item.Bonded == BondedStatus.Bonded
+                    && (keepNonEquippable || (item.ValidLocations ?? EquipMask.None) != EquipMask.None) && item.Bonded == BondedStatus.Bonded
                     && item.WeenieClassId != (int)Factories.Enum.WeenieClassName.ringHardcore
                     && item.WeenieClassId != (uint)Factories.Enum.WeenieClassName.explorationContract)
                 {


### PR DESCRIPTION
This doesn't include "items inside gem pouches" yet but bonded non-equippable items will be retained on death (also includes config)