### PR TITLE
Workaround to fix loot delay with assess_creature_pve_always_succeed (config must be updated on server)

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -681,6 +681,8 @@ namespace ACE.Server.Managers
                 ("allow_PKs_to_go_NPK", new Property<bool>(true, "Allows PKs to go back to being NPKs by using the appropriate altar")),
                 ("show_discord_chat_ingame", new Property<bool>(false, "Display messages posted to Discord in general chat")),
 
+                ("assess_creature_pve_always_succeed", new Property<bool>(false, "enable this to bypass assess creature PvE skill checks (workaround to fix 5 second delay on vtank looting which occurs due to failed assess)")),
+
                 ("fall_damage_enabled", new Property<bool>(true, "Toggles whether fall damage is enabled")),
                 ("dekaru_dual_wield_speed_mod", new Property<bool>(true, "Toggles whether Dekaru's dual wield speed changes (other than for dagger) are enabled")),
                 ("dekaru_hc_keep_non_equippable_bonded_on_death", new Property<bool>(true, "Toggles whether bonded items are kept on a hardcore death despite being non-equippable"))

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -379,6 +379,9 @@ namespace ACE.Server.WorldObjects
                 if ((this is Admin || this is Sentinel) && CloakStatus == CloakStatus.On)
                     chance = 1.0f;
 
+                if (PropertyManager.GetBool("assess_creature_pve_always_succeed").Item && player == null && creature != null)
+                    chance = 1.0f;
+
                 success = chance > ThreadSafeRandom.Next(0.0f, 1.0f);
             }
 


### PR DESCRIPTION
When an assess is failed, decal adds a 5 second delay to ID Queue, which is what causes the delay when looting. VTank attempts to assess all creatures in visible range.