### PR TITLE
Cast on Strike additions

### DIFF
--- a/Source/ACE.Server/Factories/Tables/Spells/MeleeSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/MeleeSpells.cs
@@ -109,40 +109,56 @@ namespace ACE.Server.Factories.Tables
         {
             ( SpellId.Undef,              150.0f ),
 
-            ( SpellId.StaminaToHealthSelf1, 1.0f ),
-            ( SpellId.StaminaToManaSelf1,   1.0f ),
-            ( SpellId.ManaToStaminaSelf1,   1.0f ),
-            ( SpellId.ManaToHealthSelf1,    1.0f ),
-            ( SpellId.HealthToStaminaSelf1, 1.0f ),
-            ( SpellId.HealthToManaSelf1,    1.0f ),
+            ( SpellId.StaminaToHealthSelf1,      1.0f ),
+            ( SpellId.StaminaToManaSelf1,        1.0f ),
+            ( SpellId.ManaToStaminaSelf1,        1.0f ),
+            ( SpellId.ManaToHealthSelf1,         1.0f ),
+            ( SpellId.HealthToStaminaSelf1,      1.0f ),
+            ( SpellId.HealthToManaSelf1,         1.0f ),
 
-            ( SpellId.DrainStamina1,        1.0f ),
-            ( SpellId.DrainMana1,           1.0f ),
-            ( SpellId.DrainHealth1,         1.0f ),
+            ( SpellId.DrainStamina1,             1.0f ),
+            ( SpellId.DrainMana1,                1.0f ),
+            ( SpellId.DrainHealth1,              1.0f ),
 
-            ( SpellId.BloodLoather,         1.0f ),
-            ( SpellId.LeadenWeapon1,        1.0f ),
-            ( SpellId.TurnBlade1,           1.0f ),
-            ( SpellId.Brittlemail1,         1.0f ),
+            ( SpellId.BloodLoather,              1.0f ),
+            ( SpellId.LeadenWeapon1,             1.0f ),
+            ( SpellId.TurnBlade1,                1.0f ),
+            ( SpellId.Brittlemail1,              1.0f ),
+
+            ( SpellId.MagicYieldOther1,          1.0f ),
+            ( SpellId.DefenselessnessOther1,     1.0f ),
+            ( SpellId.VulnerabilityOther1,       1.0f ),
+            ( SpellId.WarMagicIneptitudeOther1,  1.0f ),
+            ( SpellId.LifeMagicIneptitudeOther1, 1.0f ),
+
+            ( SpellId.ImperilOther1,             1.0f )
         };
 
         private static ChanceTable<SpellId> meleeProcsCertain = new ChanceTable<SpellId>(ChanceTableType.Weight)
         {
-            ( SpellId.StaminaToHealthSelf1, 1.0f ),
-            ( SpellId.StaminaToManaSelf1,   1.0f ),
-            ( SpellId.ManaToStaminaSelf1,   1.0f ),
-            ( SpellId.ManaToHealthSelf1,    1.0f ),
-            ( SpellId.HealthToStaminaSelf1, 1.0f ),
-            ( SpellId.HealthToManaSelf1,    1.0f ),
+            ( SpellId.StaminaToHealthSelf1,      1.0f ),
+            ( SpellId.StaminaToManaSelf1,        1.0f ),
+            ( SpellId.ManaToStaminaSelf1,        1.0f ),
+            ( SpellId.ManaToHealthSelf1,         1.0f ),
+            ( SpellId.HealthToStaminaSelf1,      1.0f ),
+            ( SpellId.HealthToManaSelf1,         1.0f ),
 
-            ( SpellId.DrainStamina1,        1.0f ),
-            ( SpellId.DrainMana1,           1.0f ),
-            ( SpellId.DrainHealth1,         1.0f ),
+            ( SpellId.DrainStamina1,             1.0f ),
+            ( SpellId.DrainMana1,                1.0f ),
+            ( SpellId.DrainHealth1,              1.0f ),
 
-            ( SpellId.BloodLoather,         1.0f ),
-            ( SpellId.LeadenWeapon1,        1.0f ),
-            ( SpellId.TurnBlade1,           1.0f ),
-            ( SpellId.Brittlemail1,         1.0f ),
+            ( SpellId.BloodLoather,              1.0f ),
+            ( SpellId.LeadenWeapon1,             1.0f ),
+            ( SpellId.TurnBlade1,                1.0f ),
+            ( SpellId.Brittlemail1,              1.0f ),
+
+            ( SpellId.MagicYieldOther1,          1.0f ),
+            ( SpellId.DefenselessnessOther1,     1.0f ),
+            ( SpellId.VulnerabilityOther1,       1.0f ),
+            ( SpellId.WarMagicIneptitudeOther1,  1.0f ),
+            ( SpellId.LifeMagicIneptitudeOther1, 1.0f ),
+
+            ( SpellId.ImperilOther1,             1.0f )
         };
 
         public static List<SpellId> Roll(TreasureDeath treasureDeath)

--- a/Source/ACE.Server/Factories/Tables/Spells/MissileSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/MissileSpells.cs
@@ -107,40 +107,56 @@ namespace ACE.Server.Factories.Tables
         {
             ( SpellId.Undef,              150.0f ),
 
-            ( SpellId.StaminaToHealthSelf1, 1.0f ),
-            ( SpellId.StaminaToManaSelf1,   1.0f ),
-            ( SpellId.ManaToStaminaSelf1,   1.0f ),
-            ( SpellId.ManaToHealthSelf1,    1.0f ),
-            ( SpellId.HealthToStaminaSelf1, 1.0f ),
-            ( SpellId.HealthToManaSelf1,    1.0f ),
+            ( SpellId.StaminaToHealthSelf1,      1.0f ),
+            ( SpellId.StaminaToManaSelf1,        1.0f ),
+            ( SpellId.ManaToStaminaSelf1,        1.0f ),
+            ( SpellId.ManaToHealthSelf1,         1.0f ),
+            ( SpellId.HealthToStaminaSelf1,      1.0f ),
+            ( SpellId.HealthToManaSelf1,         1.0f ),
 
-            ( SpellId.DrainStamina1,        1.0f ),
-            ( SpellId.DrainMana1,           1.0f ),
-            ( SpellId.DrainHealth1,         1.0f ),
+            ( SpellId.DrainStamina1,             1.0f ),
+            ( SpellId.DrainMana1,                1.0f ),
+            ( SpellId.DrainHealth1,              1.0f ),
 
-            ( SpellId.BloodLoather,         1.0f ),
-            ( SpellId.LeadenWeapon1,        1.0f ),
-            ( SpellId.TurnBlade1,           1.0f ),
-            ( SpellId.Brittlemail1,         1.0f ),
+            ( SpellId.BloodLoather,              1.0f ),
+            ( SpellId.LeadenWeapon1,             1.0f ),
+            ( SpellId.TurnBlade1,                1.0f ),
+            ( SpellId.Brittlemail1,              1.0f ),
+
+            ( SpellId.MagicYieldOther1,          1.0f ),
+            ( SpellId.DefenselessnessOther1,     1.0f ),
+            ( SpellId.VulnerabilityOther1,       1.0f ),
+            ( SpellId.WarMagicIneptitudeOther1,  1.0f ),
+            ( SpellId.LifeMagicIneptitudeOther1, 1.0f ),
+
+            ( SpellId.ImperilOther1,             1.0f )
         };
 
         private static ChanceTable<SpellId> missileProcsCertain = new ChanceTable<SpellId>(ChanceTableType.Weight)
         {
-            ( SpellId.StaminaToHealthSelf1, 1.0f ),
-            ( SpellId.StaminaToManaSelf1,   1.0f ),
-            ( SpellId.ManaToStaminaSelf1,   1.0f ),
-            ( SpellId.ManaToHealthSelf1,    1.0f ),
-            ( SpellId.HealthToStaminaSelf1, 1.0f ),
-            ( SpellId.HealthToManaSelf1,    1.0f ),
+            ( SpellId.StaminaToHealthSelf1,      1.0f ),
+            ( SpellId.StaminaToManaSelf1,        1.0f ),
+            ( SpellId.ManaToStaminaSelf1,        1.0f ),
+            ( SpellId.ManaToHealthSelf1,         1.0f ),
+            ( SpellId.HealthToStaminaSelf1,      1.0f ),
+            ( SpellId.HealthToManaSelf1,         1.0f ),
 
-            ( SpellId.DrainStamina1,        1.0f ),
-            ( SpellId.DrainMana1,           1.0f ),
-            ( SpellId.DrainHealth1,         1.0f ),
+            ( SpellId.DrainStamina1,             1.0f ),
+            ( SpellId.DrainMana1,                1.0f ),
+            ( SpellId.DrainHealth1,              1.0f ),
 
-            ( SpellId.BloodLoather,         1.0f ),
-            ( SpellId.LeadenWeapon1,        1.0f ),
-            ( SpellId.TurnBlade1,           1.0f ),
-            ( SpellId.Brittlemail1,         1.0f ),
+            ( SpellId.BloodLoather,              1.0f ),
+            ( SpellId.LeadenWeapon1,             1.0f ),
+            ( SpellId.TurnBlade1,                1.0f ),
+            ( SpellId.Brittlemail1,              1.0f ),
+
+            ( SpellId.MagicYieldOther1,          1.0f ),
+            ( SpellId.DefenselessnessOther1,     1.0f ),
+            ( SpellId.VulnerabilityOther1,       1.0f ),
+            ( SpellId.WarMagicIneptitudeOther1,  1.0f ),
+            ( SpellId.LifeMagicIneptitudeOther1, 1.0f ),
+
+            ( SpellId.ImperilOther1,             1.0f )
         };
 
         public static List<SpellId> Roll(TreasureDeath treasureDeath)

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -479,8 +479,8 @@ namespace ACE.Server.WorldObjects
                 if (bodyArmorMod > effectiveAL)
                     effectiveAL = bodyArmorMod; // Body armor doesn't stack with equipment armor, use whichever is highest.
 
-                if (!ignoreMagicResist)
-                    effectiveAL += defender.EnchantmentManager.GetBodyArmorMod(false); // Take into account armor debuffs now, but only if weapon isn't hollow.
+                if (!isPvP && !ignoreMagicResist)
+                    effectiveAL += defender.EnchantmentManager.GetBodyArmorMod(false); // Take into account armor debuffs now, but only if weapon isn't hollow and this is not PvP (Imperil disabled in PvP for now).
             }
 
             // Armor Rending reduces physical armor too?


### PR DESCRIPTION
- Cast on Strike additions
- Imperil disabled in PvP to retain game balance (mostly to save robe users) with the addition of Imperil CoS