### PR TITLE
Make CoS appear more often in loot

### DIFF
--- a/Source/ACE.Server/Factories/Tables/Spells/MeleeSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/MeleeSpells.cs
@@ -107,7 +107,7 @@ namespace ACE.Server.Factories.Tables
 
         public static ChanceTable<SpellId> meleeProcs = new ChanceTable<SpellId>(ChanceTableType.Weight)
         {
-            ( SpellId.Undef,              150.0f ),
+            ( SpellId.Undef,              75.0f ),
 
             ( SpellId.StaminaToHealthSelf1,      1.0f ),
             ( SpellId.StaminaToManaSelf1,        1.0f ),

--- a/Source/ACE.Server/Factories/Tables/Spells/MissileSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/MissileSpells.cs
@@ -105,7 +105,7 @@ namespace ACE.Server.Factories.Tables
 
         public static ChanceTable<SpellId> missileProcs = new ChanceTable<SpellId>(ChanceTableType.Weight)
         {
-            ( SpellId.Undef,              150.0f ),
+            ( SpellId.Undef,              75.0f ),
 
             ( SpellId.StaminaToHealthSelf1,      1.0f ),
             ( SpellId.StaminaToManaSelf1,        1.0f ),


### PR DESCRIPTION
The reason for this is that cast on strike is needed to make certain builds work, and trading is difficult on a low population server